### PR TITLE
remove sh:name

### DIFF
--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -7,7 +7,7 @@
 
 :CatalogShape a sh:NodeShape ;
   sh:targetClass dcat:Catalog ;
-  sh:name "Catalog"@en ;
+#  sh:name "Catalog"@en ;
   sh:property 
  [
     sh:path <http://www.w3.org/ns/dcat#dataset> ;

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -15,7 +15,7 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 
 :DatasetShape a sh:NodeShape ;
-sh:name "Dataset"@en ;
+#sh:name "Dataset"@en ;
   sh:targetClass dcat:Dataset ;
   sh:property 
 [

--- a/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
@@ -15,7 +15,7 @@
 
 
 :DatasetSeriesShape a sh:NodeShape ;
-sh:name "DatasetSeries"@en ;
+#sh:name "DatasetSeries"@en ;
   sh:targetClass dcat:DatasetSeries ;
   sh:property [
 sh:path <http://purl.org/dc/terms/contactPoint> ;

--- a/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
@@ -6,7 +6,7 @@
 @prefix xsd:      <http://www.w3.org/2001/XMLSchema#> .
 
 :DistributionShape a sh:NodeShape ;
-sh:name "Distribution"@en ;
+#sh:name "Distribution"@en ;
   sh:targetClass dcat:Distribution ;
 sh:property 
 [

--- a/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
@@ -8,7 +8,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 :ResourceShape a sh:NodeShape ;
-sh:name "Resource"@en ;
+#sh:name "Resource"@en ;
   sh:targetClass dcat:Resource ;
   sh:property [
     sh:path dct:title ;


### PR DESCRIPTION
the underlying library interprets sh:name value as a PropertyShape, even when it is explicitly typed as a NodeShape. This will trigger an error in the parsing of the shapes. Removing the sh:name triples from NodeShapes will solve it.