### PR TITLE
ci: added conventional commit linting on PR

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,11 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ],
+    "rules": {
+        "body-max-line-length": [
+            0,
+            "always"
+        ]
+    }
+}

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,13 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,5 +9,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v6
+        with:
+            configFile: "./.commitlintrc.json"


### PR DESCRIPTION
This pull request adds linting for the Conventional Commit specifications.

It uses the Angular contribution guidelines, see angular: https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines