### PR TITLE
feat: show an input box to get identifier

### DIFF
--- a/Formalisation(shacl)/Core/Example-Data/example-dataset.ttl
+++ b/Formalisation(shacl)/Core/Example-Data/example-dataset.ttl
@@ -8,21 +8,24 @@
 <http://example.com/dataset> a dcat:Dataset ;
     dct:title "Example Dataset" ;
     dct:description "This is an example dataset to test the shapes" ;
-    dct:identifier "test-id" ;
+    dct:identifier "test-dataset-id-0" ;
     dct:issued "2024-05-27T15:00:00+02:00"^^xsd:dateTime ;
     dcat:theme <http://www.wikidata.org/entity/Q1141613> ;
     dct:creator [
         a foaf:Agent ;
         foaf:name "Test" ;
+        dct:identifier "test-creator-id-000" ;
     ] .
 
 
 <http://example.com/dataset/1> a dcat:Dataset ;
     dct:creator [ a foaf:Agent  ;
             foaf:name "Hermione Granger" ;
+            dct:identifier "test-creator-id-001" ;
             vcard:hasUID <https://harrypotter.fandom.com/wiki/Hermione_Granger> ] ;
+
     dct:description "Impact of muggle technical inventions on word's magic presense" ;
-    dct:identifier "1" ;
+    dct:identifier "test-dataset-id-1" ;
     dct:issued "1992-03-04T00:00:00"^^xsd:dateTime ;
     dct:publisher [ a foaf:Agent ;
             dct:identifier "https://harrypotter.fandom.com/wiki/Gryffindor" ;
@@ -36,9 +39,10 @@
 <http://example.com/dataset/2> a dcat:Dataset ;
     dct:creator [ a foaf:Agent ;
             foaf:name "Draco Malfoy" ;
+			dct:identifier "test-creator-id-002" ;
             vcard:hasUID <https://harrypotter.fandom.com/wiki/Draco_Malfoy> ] ;
     dct:description "Comarative analysis of magic powers of muggle-born and blood wizards " ;
-    dct:identifier "2" ;
+    dct:identifier "test-dataset-id-12" ;
     dct:issued "1992-05-25T00:00:00"^^xsd:dateTime ;
     dct:publisher [ a foaf:Agent ;
             dct:identifier "https://harrypotter.fandom.com/wiki/Slytherin" ;
@@ -55,9 +59,10 @@
 <http://example.com/dataset/3> a dcat:Dataset ;
     dct:creator [ a foaf:Agent ;
             foaf:name "Luna Lovegood" ;
+			dct:identifier "test-creator-id-003" ;
             vcard:hasUID <https://harrypotter.fandom.com/wiki/Luna_Lovegood> ] ;
     dct:description "Linguistic analysis of spells" ;
-    dct:identifier "3" ;
+    dct:identifier "test-dataset-id-3" ;
     dct:issued "1992-05-26T00:00:00"^^xsd:dateTime ;
     dct:publisher [ a foaf:Agent ;
             dct:identifier "https://harrypotter.fandom.com/wiki/Ravenclaw" ;
@@ -69,9 +74,10 @@
 <http://example.com/dataset/4> a dcat:Dataset ;
     dct:creator [ a foaf:Agent ;
             foaf:name "Dora Williams" ;
+			dct:identifier "test-creator-id-004" ;
             vcard:hasUID <https://harrypotter.fandom.com/wiki/Dora_Williams> ] ;
     dct:description "Domestics elfs reproduction rate changes in the last 100 years" ;
-    dct:identifier "4" ;
+    dct:identifier "test-dataset-id-4" ;
     dct:issued "1992-05-27T00:00:00"^^xsd:dateTime ;
     dct:publisher [ a foaf:Agent ;
             dct:identifier "https://harrypotter.fandom.com/wiki/Hufflepuff" ;

--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -66,7 +66,8 @@
         sh:property     
 		[ 
 		sh:path      foaf:name;
-    dash:editor  dash:TextFieldEditor;
+    dash:editor dash:TextFieldEditor;
+	dash:viewer dash:LiteralViewer ;
     sh:maxCount  1;
     sh:minCount  1;
     sh:nodeKind  sh:Literal;
@@ -74,6 +75,8 @@
   	[
 		sh:path dct:identifier ;
 		sh:nodeKind sh:Literal ;
+		dash:viewer dash:LiteralViewer ;
+		dash:editor dash:TextFieldEditor ;
 		sh:minCount 1 ;
 		sh:maxCount 1 ;
   ];

--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -63,9 +63,9 @@
 
 
   :AgentShape  a   sh:NodeShape;
-        sh:property     
-		[ 
-		sh:path      foaf:name;
+    sh:property     
+	[ 
+	sh:path      foaf:name;
     dash:editor dash:TextFieldEditor;
 	dash:viewer dash:LiteralViewer ;
     sh:maxCount  1;
@@ -73,11 +73,13 @@
     sh:nodeKind  sh:Literal;
     ],
   	[
-		sh:path dct:identifier ;
-		sh:nodeKind sh:Literal ;
-		dash:viewer dash:LiteralViewer ;
-		dash:editor dash:TextFieldEditor ;
-		sh:minCount 1 ;
-		sh:maxCount 1 ;
+	sh:path dct:identifier ;
+	sh:nodeKind sh:Literal ;
+	dash:viewer dash:LiteralViewer ;
+	dash:editor dash:TextFieldEditor ;
+	sh:minCount 1 ;
+	sh:maxCount 1 ;
   ];
+  
   sh:targetClass  foaf:Agent .
+  

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -132,14 +132,23 @@
     dash:viewer dash:LabelViewer ;
   ] .
 
+
 :AgentShape a sh:NodeShape;
   sh:property     
   [ 
-    dash:editor dash:TextFieldEditor ;
-    dash:viewer dash:LiteralViewer ;
-    sh:maxCount 1 ;
-    sh:minCount 1 ;
-    sh:nodeKind sh:Literal ;
     sh:path foaf:name ;
-  ] ;
-  sh:targetClass foaf:Agent .
+    sh:nodeKind sh:Literal ;
+    dash:viewer dash:LiteralViewer ;
+    dash:editor dash:TextFieldEditor ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ] ,
+  [
+    sh:path dct:identifier ;
+    sh:nodeKind sh:Literal ;
+    dash:viewer dash:LiteralViewer ;
+    dash:editor dash:TextFieldEditor ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ];
+sh:targetClass foaf:Agent .

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -151,4 +151,5 @@
     sh:minCount 1 ;
     sh:maxCount 1 ;
   ];
+
 sh:targetClass foaf:Agent .


### PR DESCRIPTION
In AgentShape, the Identifier is mandatory. The publisher is of type AgentShape, it is required to input an ID for the publisher. A box should be displayed for a user to input the ID, that requeirs the dash:viewer dash:LiteralViewer ;  dash:editor dash:TextFieldEditor ; for the identifier.