### PR TITLE
test: created PyTest harness for SHACL  testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install pyshacl
-
-      - name: Test catalog shape against catalog fixture
-        run: pyshacl --shacl "Formalisation(shacl)/Core/PiecesShape/Catalog.ttl" --metashacl "Formalisation(shacl)/Core/Example-Data/example-catalog.ttl"
-
-      - name: Test dataset shape against dataset fixture
-        run: pyshacl --shacl "Formalisation(shacl)/Core/PiecesShape/Dataset.ttl" --metashacl "Formalisation(shacl)/Core/Example-Data/example-dataset.ttl"
-
-      - name: Test distribution shape against distribution fixture
-        run: pyshacl --shacl "Formalisation(shacl)/Core/PiecesShape/Distribution.ttl" --metashacl "Formalisation(shacl)/Core/Example-Data/example-distribution.ttl"
+          cache: 'pip' # caching pip dependencies
+      - name: Install Hatch
+        run: pipx install hatch
+        
+      - name: Run tests
+        run: hatch run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Automated SHACL validation testing
-on: [ push ]
+on: [ push, pull_request ]
 jobs:
   shacl_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-name: Continuous Integration
+name: Automated SHACL validation testing
 on: [ push ]
 jobs:
-  ci:
+  shacl_test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Automated SHACL validation testing
 on: [ push, pull_request ]
 jobs:
-  shacl_test:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,18 @@
-
 health-ri-metadata/
 
 # ignore mac metadata
 .DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Word temporary files
+~$*
+
+# Visual paradigm temporary files
+*.vpp.bak_*
+
+# Other temporary files
+*.tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,93 @@
+[project]
+name = "healthri-metadata"
+version = "1.0"
+requires-python = ">=3.8"
+dependencies = ["rdflib ~= 7.0", "pyshacl ~= 0.26", "pytest ~= 8.2"]
+
+[build-system]
+requires = ["hatchling >= 1.19.1"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+addopts = [
+    "--doctest-modules",
+    "--ignore=admin",
+    "--ignore=devtools",
+    "--ignore=rdflib/extras/external_graph_libs.py",
+    "--ignore-glob=docs/*.py",
+    "--doctest-glob=docs/*.rst",
+    "--strict-markers",
+]
+filterwarnings = [
+    # The below warning is a consequence of how pytest doctest detects mocks and how DefinedNamespace behaves when an undefined attribute is being accessed.
+    "ignore:Code. pytest_mock_example_attribute_that_shouldnt_exist is not defined in namespace .*:UserWarning",
+    # The below warning is a consequence of how pytest detects fixtures and how DefinedNamespace behaves when an undefined attribute is being accessed.
+    "ignore:Code. _pytestfixturefunction is not defined in namespace .*:UserWarning",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["tests/"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = ["black>=23.1.0", "ruff>=0.0.243"]
+
+
+[tool.ruff]
+lint.select = [
+    "A",
+    "ARG",
+    "B",
+    "C",
+    "DTZ",
+    "E",
+    "EM",
+    "F",
+    "FBT",
+    "I",
+    "ICN",
+    "ISC",
+    "N",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    "Q",
+    "RUF",
+    "S",
+    "T",
+    "TID",
+    "UP",
+    "W",
+    "YTT",
+]
+target-version = "py38"
+line-length = 120
+lint.ignore = [
+    # Allow non-abstract empty methods in abstract base classes
+    "B027",
+    # Allow boolean positional values in function calls, like `dict.get(... True)`
+    "FBT003",
+    # Ignore checks for possible passwords
+    "S105",
+    "S106",
+    "S107",
+    # Ignore complexity
+    "C901",
+    "PLR0911",
+    "PLR0912",
+    "PLR0913",
+    "PLR0915",
+]
+
+# Taken from https://github.com/astral-sh/ruff/issues/4368
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    # at least this three should be fine in tests:
+    "S101", # asserts allowed in tests...
+    "ARG",  # Unused function args -> fixtures nevertheless are functionally relevant...
+    "FBT",  # Don't care about booleans as positional arguments in tests, e.g. via @pytest.mark.parametrize()
+    # The below are debateable
+    "PLR2004", # Magic value used in comparison, ...
+    "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ filterwarnings = [
 [tool.hatch.build.targets.wheel]
 packages = ["tests/"]
 
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests}"
+
 [tool.hatch.envs.lint]
 detached = true
 dependencies = ["black>=23.1.0", "ruff>=0.0.243"]

--- a/tests/TestingDocumentation.md
+++ b/tests/TestingDocumentation.md
@@ -1,0 +1,26 @@
+# Documentation for the testing harness
+
+## Introduction
+
+This folder contains files related to a testing harness for the SHACL shapes. The main purpose of
+these is to catch errors at an early stage in development, for example data that should validate
+but fails to validate, or minor syntax errors that hadn't come up before. We do this by testing
+the shapes against test data of which we know the expected test result.
+
+## Running the tests
+
+The tests are automatically run by Github actions on every pull request. However, you can also run
+these locally. You will need to have [Hatch](https://www.python.org/) installed on your computer.
+To install Hatch, follow the instructions at this link for your operating system: <https://hatch.pypa.io/latest/install/>
+
+To run the tests, go to your commandline of choice and running `hatch run test`. You will get a test report then.
+
+If any of the tests fail, the testing tool will show you which test failed and what the associated
+error message was.
+
+## Developing your own tests
+
+> **Note:** This section is to be expanded
+
+The testing is performed using [pySHACL](https://github.com/RDFLib/pySHACL) and [pytest](https://docs.pytest.org/).
+Full documentation on these tools is currently outside of the scope of this document.

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -11,8 +11,8 @@ from pyshacl import validate
     ],
 )
 def test_core_shapes(shacl, example):
-    shacl_graph = rf"Formalisation(shacl)/Core/PiecesShape/{shacl}.ttl"
-    example_graph = rf"Formalisation(shacl)/Core/Example-Data/{example}.ttl"
+    shacl_graph = get_shacl_path(shacl)
+    example_graph = get_example_path(example)
 
     conform, _, result_text = validate(
         data_graph=example_graph,
@@ -21,3 +21,9 @@ def test_core_shapes(shacl, example):
         meta_shacl=True,
     )
     assert conform, result_text
+
+def get_example_path(example):
+    return rf"Formalisation(shacl)/Core/Example-Data/{example}.ttl"
+
+def get_shacl_path(shacl):
+    return rf"Formalisation(shacl)/Core/PiecesShape/{shacl}.ttl"

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -1,0 +1,23 @@
+import pytest
+from pyshacl import validate
+
+
+@pytest.mark.parametrize(
+    ("shacl", "example"),
+    [
+        ("Catalog", "example-catalog"),
+        ("Dataset", "example-dataset"),
+        ("Distribution", "example-distribution"),
+    ],
+)
+def test_core_shapes(shacl, example):
+    shacl_graph = rf"Formalisation(shacl)/Core/PiecesShape/{shacl}.ttl"
+    example_graph = rf"Formalisation(shacl)/Core/Example-Data/{example}.ttl"
+
+    conform, _, result_text = validate(
+        data_graph=example_graph,
+        shacl_graph=shacl_graph,
+        allow_warnings=False,
+        meta_shacl=True,
+    )
+    assert conform, result_text


### PR DESCRIPTION
Initial pytest harness for the SHACLs

Right now I used parametrized tests for the core shapes. It'll be possible to add more tests, also tests that have to fail, xpass/xfail tests etc.