### PR TITLE
ci: added an example of a dataset that should fail

### DIFF
--- a/Formalisation(shacl)/Core/Example-Data/example-dataset-bad.ttl
+++ b/Formalisation(shacl)/Core/Example-Data/example-dataset-bad.ttl
@@ -1,0 +1,12 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+# This dataset has wrong types for publisher and contactpoint
+<http://example.com/dataset/AAA> a dcat:Dataset ;
+    dct:description "An Abdomination of a dataset" ;
+    dcat:issued "2024-01-01T13:33:37.069+02:00" ;
+    dct:publisher [ a vcard:Kind ; vcard:fn "Bad non-conforming publisher" ] ;
+    dct:title "AAA" ;
+    dcat:contactPoint [ a foaf:agent ; foaf:name "Prof. Dr. John Doe" ] .

--- a/tests/test_shacl.py
+++ b/tests/test_shacl.py
@@ -22,6 +22,25 @@ def test_core_shapes(shacl, example):
     )
     assert conform, result_text
 
+@pytest.mark.parametrize(
+    ("shacl", "example"),
+    [
+        ("Dataset", "example-dataset-bad"),
+    ],
+)
+def test_core_shapes_negative(shacl, example):
+    shacl_graph = get_shacl_path(shacl)
+    example_graph = get_example_path(example)
+
+    conform, _, result_text = validate(
+        data_graph=example_graph,
+        shacl_graph=shacl_graph,
+        allow_warnings=False,
+        meta_shacl=True,
+    )
+    assert not conform, result_text
+
+
 def get_example_path(example):
     return rf"Formalisation(shacl)/Core/Example-Data/{example}.ttl"
 


### PR DESCRIPTION
This dataset should always fail: publisher is a vcard and contactpoint is a foaf.

Draft as we want to add a few more test cases.