### PR TITLE
ci: only run shacl validation on PRs that actually modify them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Automated SHACL validation testing
-on: [ push, pull_request ]
+on:
+  # Only run the SHACL testing if SHACLs or testing has actually changed
+  pull_request:
+    paths:
+      - 'Formalisation(shacl)/**'
+      - 'tests/**'
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Simple change to the shacl testing yaml, so it only runs when the SHACLs (or test cases!) have been modified.
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore