### PR TITLE
feat: vcard fn, hasEmail, hasURL

### DIFF
--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -166,13 +166,19 @@ sh:targetClass foaf:Agent .
     sh:maxCount 1 ;
   ] ,
   [
-    sh:path vcard:hasName ;
+    sh:path vcard:fn ;
     sh:nodeKind sh:Literal ;
     dash:viewer dash:LiteralViewer ;
     dash:editor dash:TextFieldEditor ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
-  ];
+  ] ,
+  [ 
+    sh:path vcard:hasURL ;
+    sh:nodeKind sh:IRI ;
+    dash:viewer dash:URIViewer ;
+    dash:editor dash:URIEditor ;
+  ] ;
 
 sh:targetClass vcard:Kind .
 


### PR DESCRIPTION
Based on the discussion in Metadata and FDP channel on Teams: class vcard:Kind has mandatory properties vcard:fn and vcard:hasEmail and maybe add vcard:hasURL as recommended to be compliant with healthDCAT-AP.