### PR TITLE
ci: only allow develop to merge into master

### DIFF
--- a/.github/workflows/enforcer.yml
+++ b/.github/workflows/enforcer.yml
@@ -1,0 +1,14 @@
+name: 'Check correct PR branch'
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'master' && github.head_ref != 'develop'
+        run: |
+          echo "ERROR: You can only merge to master from the develop branch."
+          exit 1


### PR DESCRIPTION
This PR adds a simple Github actions workflow that checks one and only one thing: that PRs to the master branch come directly from develop.
It will throw an error if you try to merge a different PR into master by accident.

Inspired by https://stackoverflow.com/questions/71120146/allowing-only-certain-branches-to-pr-merge-to-mainmaster-branch
