### PR TITLE
feat: replace anyUri by literal

### DIFF
--- a/Formalisation(shacl)/Core/FairDataPointShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Catalog.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Catalog"@en;
   rdfs:comment "Health-RI v2 Catalog."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Catalog."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Catalog."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:14:36.480Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:16.780Z"^^xsd:dateTime .
 
 hri:CatalogShape a sh:NodeShape;
   rdfs:label "Catalog"@en;
@@ -69,7 +69,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dcterms:creator;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dct:creator;
   sh:name "creator"@en;
   sh:node hri:AgentShape;
   dash:viewer dash:DetailsViewer;
@@ -78,21 +78,21 @@ hri:CatalogShape a sh:NodeShape;
 <http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset> sh:path dcat:dataset;
   sh:name "dataset"@en .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:minCount 1;
   sh:nodeKind sh:Literal;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextAreaEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dct:spatial;
   sh:name "geographical coverage"@en;
   sh:description "The EU Vocabularies Name Authority Lists must be used for continents, countries and places that are in those lists; if a particular location is not in one of the mentioned Named Authority Lists, Geonames URIs must be used. For districts or neighbourhoods in NL, the Dutch vocab can be used."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dcterms:hasPart;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dct:hasPart;
   sh:name "has part"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -105,27 +105,27 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dct:license;
   sh:name "licence"@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dct:publisher;
   sh:name "publisher"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -137,14 +137,14 @@ hri:CatalogShape a sh:NodeShape;
   sh:name "record"@en;
   sh:class dcat:CatalogRecord .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
@@ -157,7 +157,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dcterms:temporal;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dct:temporal;
   sh:name "temporal coverage"@en;
   sh:node hri:PeriodOfTimeShape;
   dash:viewer dash:DetailsViewer;
@@ -170,7 +170,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:minCount 1;
   sh:nodeKind sh:Literal;
@@ -180,9 +180,9 @@ hri:CatalogShape a sh:NodeShape;
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
   rdfs:comment "Excel template for Agent class"@en;
-  dcterms:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
 hri:AgentShape a sh:NodeShape;
   rdfs:label "Agent"@en;
@@ -192,7 +192,7 @@ hri:AgentShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
     <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
   sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -209,7 +209,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "A unique identifier of the agent."@en;
   sh:minCount 1;
@@ -242,7 +242,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
   sh:maxCount 1;
@@ -262,9 +262,9 @@ hri:AgentShape a sh:NodeShape;
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-17T12:58:47.890Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -302,13 +302,13 @@ hri:KindShape a sh:NodeShape;
 hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:label "Period of Time"@en;
   rdfs:comment "Health-RI v2 Period of Time"@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:16:09.790Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:13.170Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;
-  sh:targetClass dcterms:PeriodOfTime;
+  sh:targetClass dct:PeriodOfTime;
   sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
 
 <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
@@ -316,7 +316,6 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The end of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -325,6 +324,5 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The start of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .

--- a/Formalisation(shacl)/Core/FairDataPointShape/DataService.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/DataService.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "DataService"@en;
   rdfs:comment "Health-RI v2 DataService."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for DataService."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for DataService."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:14:59.140Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:32.440Z"^^xsd:dateTime .
 
 hri:DataServiceShape a sh:NodeShape;
   rdfs:label "DataService"@en;
@@ -51,7 +51,7 @@ hri:DataServiceShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher>, <http://data.health-ri.nl/core/p2/DataServiceShape#dcat:servesDataset>,
     <http://data.health-ri.nl/core/p2/DataServiceShape#dcat:theme>, <http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:accessRights> sh:path dcterms:accessRights;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:accessRights> sh:path dct:accessRights;
   sh:name "Access Rights"@en;
   sh:description "Information that indicates whether the Dataset is publicly accessible, has access restrictions or is not public. Use one of the following values (:public, :restricted, :non-public)."@en;
   sh:minCount 1;
@@ -68,7 +68,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:conformsTo> sh:path dcterms:conformsTo;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:conformsTo> sh:path dct:conformsTo;
   sh:name "application profile"@en;
   sh:description "The standards referred here SHOULD describe the Data Service and not the data it serves. The latter is provided by the dataset with which this Data Service is connected. For instance the data service adheres to the OGC WFS API standard, while the associated dataset adheres to the INSPIRE Address data model."@en;
   sh:nodeKind sh:IRI;
@@ -84,19 +84,19 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:creator> sh:path dcterms:creator;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:creator> sh:path dct:creator;
   sh:name "creator"@en;
   sh:node hri:AgentShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:description> sh:path dct:description;
   sh:name "Description"@en;
   sh:description "A free-text account of the Data Service."@en;
   sh:minCount 1;
@@ -123,7 +123,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:format> sh:path dcterms:format;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:format> sh:path dct:format;
   sh:name "format"@en;
   sh:description "The structure that can be returned by querying the endpointURL."@en;
   sh:nodeKind sh:IRI;
@@ -136,7 +136,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:identifier> sh:path dct:identifier;
   sh:name "Identifier"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -158,13 +158,13 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:license> sh:path dct:license;
   sh:name "License"@en;
   sh:description "A licence under which the Data service is made available."@en;
   sh:minCount 1;
@@ -173,7 +173,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
@@ -186,7 +186,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher> sh:path dct:publisher;
   sh:name "Publisher"@en;
   sh:description "An entity (organisation) responsible for making the Data Service available."@en;
   sh:minCount 1;
@@ -210,7 +210,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "A name given to the Data Service."@en;
   sh:minCount 1;
@@ -221,9 +221,9 @@ hri:DataServiceShape a sh:NodeShape;
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
   rdfs:comment "Excel template for Agent class"@en;
-  dcterms:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
 hri:AgentShape a sh:NodeShape;
   rdfs:label "Agent"@en;
@@ -233,7 +233,7 @@ hri:AgentShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
     <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
   sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -246,10 +246,11 @@ hri:AgentShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
+  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "A unique identifier of the agent."@en;
   sh:minCount 1;
@@ -282,7 +283,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
   sh:maxCount 1;
@@ -302,9 +303,9 @@ hri:AgentShape a sh:NodeShape;
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:15:54.050Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -326,6 +327,7 @@ hri:KindShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
+  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/FairDataPointShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Dataset.ttl
@@ -1,15 +1,16 @@
 @prefix schema: <http://schema.org/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix dqv: <https://www.w3.org/TR/vocab-dqv/> .
+@prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <http://data.health-ri.nl/core/p2/DatasetShape> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -23,6 +24,7 @@
 @prefix dpv: <https://w3id.org/dpv#> .
 @prefix efo: <http://www.ebi.ac.uk/efo/efo.owl/> .
 @prefix eu: <http://publications.europa.eu/resource/authority/access-right/> .
+@prefix dpv-pd: <https://w3id.org/dpv/dpv-pd#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
@@ -35,9 +37,9 @@
 hri:DatasetShape a owl:Ontology, sh:NodeShape;
   rdfs:label "Excel template for Dataset class"@en, "Dataset"@en;
   rdfs:comment "Excel template for Dataset class"@en;
-  dcterms:description "This is an excel template for Dataset class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Dataset class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-02-10T00:00:00.000Z"^^xsd:dateTime;
+  dct:modified "2025-02-10T00:00:00.000Z"^^xsd:dateTime;
   sh:targetClass dcat:Dataset;
   sh:property <http://data.health-ri.nl/core/p2/DatasetShape#access-rights>, <http://data.health-ri.nl/core/p2/DatasetShape#analytics>,
     <http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation>, <http://data.health-ri.nl/core/p2/DatasetShape#code-values>,
@@ -62,28 +64,27 @@ hri:DatasetShape a owl:Ontology, sh:NodeShape;
     <http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage>, <http://data.health-ri.nl/core/p2/DatasetShape#temporal-resolution>,
     <http://data.health-ri.nl/core/p2/DatasetShape#theme>, <http://data.health-ri.nl/core/p2/DatasetShape#title>,
     <http://data.health-ri.nl/core/p2/DatasetShape#type>, <http://data.health-ri.nl/core/p2/DatasetShape#version>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#version-notes>, <http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#was-used-by> .
+    <http://data.health-ri.nl/core/p2/DatasetShape#version-notes>, <http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by> .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#access-rights> sh:path dcterms:accessRights;
+<http://data.health-ri.nl/core/p2/DatasetShape#access-rights> sh:path dct:accessRights;
   sh:name "access rights"@en;
   sh:description "Information that indicates whether the Dataset is publicly accessible, has access restrictions or is not public"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:genid-3891ca980aa44f72bfe58464c0c4413f17-3FD13CAECAC481E7A539AF0D0CC9C1D8;
+  sh:in _:genid-abf777c63d194ae894386f41fae78ca09-0F8FCE48429CA7F5158C889E25EBEC82;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:genid-3891ca980aa44f72bfe58464c0c4413f17-3FD13CAECAC481E7A539AF0D0CC9C1D8 rdf:first
+_:genid-abf777c63d194ae894386f41fae78ca09-0F8FCE48429CA7F5158C889E25EBEC82 rdf:first
     eu:PUBLIC;
-  rdf:rest _:genid-3891ca980aa44f72bfe58464c0c4413f17-7C0E81F3DAE90850E0EEF1A35DB0A122 .
+  rdf:rest _:genid-abf777c63d194ae894386f41fae78ca09-A9A638A2DF2E416646FA071329FCEE2A .
 
-_:genid-3891ca980aa44f72bfe58464c0c4413f17-7C0E81F3DAE90850E0EEF1A35DB0A122 rdf:first
+_:genid-abf777c63d194ae894386f41fae78ca09-A9A638A2DF2E416646FA071329FCEE2A rdf:first
     eu:RESTRICTED;
-  rdf:rest _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 .
+  rdf:rest _:genid-abf777c63d194ae894386f41fae78ca09-A285BD426B6EC32231255310A2357CF7 .
 
-_:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:first
+_:genid-abf777c63d194ae894386f41fae78ca09-A285BD426B6EC32231255310A2357CF7 rdf:first
     eu:NON_PUBLIC;
   rdf:rest rdf:nil .
 
@@ -97,7 +98,9 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
 <http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation> sh:path dcatap:applicableLegislation;
   sh:name "applicable legislation"@en;
   sh:description "The legislation that mandates the creation or management of the Dataset."@en;
+  sh:minCount 1;
   sh:nodeKind sh:IRI;
+  sh:defaultValue <http://data.europa.eu/eli/reg/2025/327/oj>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -115,7 +118,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#conforms-to> sh:path dcterms:conformsTo;
+<http://data.health-ri.nl/core/p2/DatasetShape#conforms-to> sh:path dct:conformsTo;
   sh:name "conforms to"@en;
   sh:description "An implementing rule or other specification"@en;
   sh:nodeKind sh:IRI;
@@ -131,7 +134,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#creator> sh:path dcterms:creator;
+<http://data.health-ri.nl/core/p2/DatasetShape#creator> sh:path dct:creator;
   sh:name "creator"@en;
   sh:description "An entity responsible for producing the dataset."@en;
   sh:minCount 1;
@@ -147,7 +150,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:BooleanSelectEdito .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DatasetShape#description> sh:path dct:description;
   sh:name "description"@en;
   sh:description "A free-text account of the Dataset."@en;
   sh:minCount 1;
@@ -170,7 +173,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#frequency> sh:path dcterms:accrualPeriodicity;
+<http://data.health-ri.nl/core/p2/DatasetShape#frequency> sh:path dct:accrualPeriodicity;
   sh:name "frequency"@en;
   sh:description "The frequency at which the Dataset is updated"@en;
   sh:maxCount 1;
@@ -178,7 +181,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage> sh:path dct:spatial;
   sh:name "geographical coverage"@en;
   sh:description "A geographic region that is covered by the Dataset."@en;
   sh:nodeKind sh:IRI;
@@ -199,13 +202,12 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/DatasetShape#identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "The main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue."@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
@@ -216,7 +218,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by> sh:path dcterms:isReferencedBy;
+<http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by> sh:path dct:isReferencedBy;
   sh:name "is referenced by"@en;
   sh:description "A related resource, such as a publication, that references, cites, or otherwise points to the dataset."@en;
   sh:nodeKind sh:IRI;
@@ -232,17 +234,18 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/DatasetShape#language> sh:path dct:language;
   sh:name "language"@en;
   sh:description "A language of the Dataset."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dqv:hasLegalBasis;
+<http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dpv:hasLegalBasis;
   sh:name "legal basis"@en;
   sh:description "The legal basis used to justify processing of personal data"@en;
   sh:nodeKind sh:IRI;
+  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -264,7 +267,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#modification-date> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DatasetShape#modification-date> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:description "The most recent date on which the Dataset was changed or modified."@en;
   sh:maxCount 1;
@@ -295,14 +298,15 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
 <http://data.health-ri.nl/core/p2/DatasetShape#other-identifier> sh:path adms:identifier;
   sh:name "other identifier"@en;
   sh:description "A secondary identifier of the Dataset, such as MAST/ADS17, DataCite18, DOI19, EZID20 or W3ID21"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
+  sh:node hri:IdentifierShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dqv:hasPersonalData;
+<http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dpv:hasPersonalData;
   sh:name "personal data"@en;
   sh:description "Key elements that represent an individual in the dataset."@en;
   sh:nodeKind sh:IRI;
+  sh:defaultValue <https://w3id.org/dpv/dpv-pd#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 
@@ -314,7 +318,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/DatasetShape#publisher> sh:path dct:publisher;
   sh:name "publisher"@en;
   sh:description "An entity (organisation) responsible for making the Dataset available."@en;
   sh:minCount 1;
@@ -323,35 +327,36 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dqv:hasPurpose;
+<http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dpv:hasPurpose;
   sh:name "purpose"@en;
   sh:description "A free text statement of the purpose of the processing of data or personal data."@en;
   sh:nodeKind sh:IRI;
+  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 
 <http://data.health-ri.nl/core/p2/DatasetShape#qualified-attribution> sh:path prov:qualifiedAttribution;
   sh:name "qualified attribution"@en;
   sh:description "An Agent having some form of responsibility for the resource"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
+  sh:node hri:AttributionShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
 
 <http://data.health-ri.nl/core/p2/DatasetShape#qualified-relation> sh:path dcat:qualifiedRelation;
   sh:name "qualified relation"@en;
   sh:description "A description of a relationship with another resource"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
+  sh:node hri:RelationshipShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
 
 <http://data.health-ri.nl/core/p2/DatasetShape#quality-annotation> sh:path dqv:hasQualityAnnotation;
   sh:name "quality annotation"@en;
   sh:description "A statement related to quality of the Dataset, including rating, quality certificate, feedback that can be associated to the dataset"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
+  sh:node hri:QualityCertificateShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#release-date> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/DatasetShape#release-date> sh:path dct:issued;
   sh:name "release date"@en;
   sh:description "The date of formal issuance (e.g., publication) of the Dataset."@en;
   sh:maxCount 1;
@@ -375,7 +380,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#source> sh:path dcterms:source;
+<http://data.health-ri.nl/core/p2/DatasetShape#source> sh:path dct:source;
   sh:name "source"@en;
   sh:description "A related dataset from which the described dataset is derived"@en;
   sh:nodeKind sh:IRI;
@@ -390,7 +395,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage> sh:path dcterms:temporal;
+<http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage> sh:path dct:temporal;
   sh:name "temporal coverage"@en;
   sh:description "A temporal period that the Dataset covers."@en;
   sh:node hri:PeriodOfTimeShape;
@@ -411,10 +416,11 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   sh:description "A category of the Dataset"@en;
   sh:minCount 1;
   sh:nodeKind sh:IRI;
+  sh:defaultValue <http://publications.europa.eu/resource/authority/data-theme/HEAL>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DatasetShape#title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "A name given to the Dataset."@en;
   sh:minCount 1;
@@ -423,7 +429,7 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/DatasetShape#type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the Dataset."@en;
   sh:maxCount 1;
@@ -455,18 +461,12 @@ _:genid-3891ca980aa44f72bfe58464c0c4413f17-71FE7C0B2C2098D1BE994A0680D14C02 rdf:
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetShape#was-used-by> sh:path prov:wasUsedBy;
-  sh:name "was used by"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
   rdfs:comment "Excel template for Agent class"@en;
-  dcterms:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
 hri:AgentShape a sh:NodeShape;
   rdfs:label "Agent"@en;
@@ -476,7 +476,7 @@ hri:AgentShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
     <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
   sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -493,7 +493,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "A unique identifier of the agent."@en;
   sh:minCount 1;
@@ -526,7 +526,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
   sh:maxCount 1;
@@ -546,9 +546,9 @@ hri:AgentShape a sh:NodeShape;
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-17T12:58:47.890Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -586,13 +586,13 @@ hri:KindShape a sh:NodeShape;
 hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:label "Period of Time"@en;
   rdfs:comment "Health-RI v2 Period of Time"@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:16:09.790Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:13.170Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;
-  sh:targetClass dcterms:PeriodOfTime;
+  sh:targetClass dct:PeriodOfTime;
   sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
 
 <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
@@ -600,7 +600,6 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The end of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -609,6 +608,121 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The start of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
+
+hri:aux-AttributionShape a owl:Ontology;
+  rdfs:label "Attribution"@en;
+  rdfs:comment "Health-RI v2 Attribution"@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Attribution."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-04-23T13:25:20.480Z"^^xsd:dateTime .
+
+hri:AttributionShape a sh:NodeShape;
+  rdfs:label "Attribution"@en;
+  sh:targetClass prov:Attribution;
+  sh:property <http://data.health-ri.nl/core/p2/AttributionShape#prov:agent>, <http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> .
+
+<http://data.health-ri.nl/core/p2/AttributionShape#prov:agent> sh:path prov:agent;
+  sh:name "agent"@en;
+  sh:description "The agent that has a specific role with the described resource."@en;
+  sh:maxCount 1;
+  sh:node hri:AgentShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> sh:path dcat:hadRole;
+  sh:name "role"@en;
+  sh:description "The nature of the relationship between the agent and the described resource, as indicated by a value from the controlled vocabulary."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:LabelViewer;
+  dash:editor dash:URIEditor .
+
+hri:aux-IdentifierShape a owl:Ontology;
+  rdfs:label "Identifier"@en;
+  rdfs:comment "Health-RI v2 Identifier"@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Identifier."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-04-23T13:25:22.090Z"^^xsd:dateTime .
+
+hri:IdentifierShape a sh:NodeShape;
+  rdfs:label "Identifier"@en;
+  sh:targetClass adms:Identifier;
+  sh:property <http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation>, <http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> .
+
+<http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation> sh:path skos:notation;
+  sh:name "notation"@en;
+  sh:description "A string that is an identifier in the context of the identifier scheme referenced by its datatype."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> sh:path adms:schemaAgency;
+  sh:name "schema agency"@en;
+  sh:description "The name of the agency that issued the identifier."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+hri:aux-QualityCertificateShape a owl:Ontology;
+  rdfs:label "Quality Certificate"@en;
+  rdfs:comment "Health-RI v2 Quality Certificate"@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Quality Certificate."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-04-23T13:25:27.610Z"^^xsd:dateTime .
+
+hri:QualityCertificateShape a sh:NodeShape;
+  rdfs:label "Quality Certificate"@en;
+  sh:targetClass dqv:QualityCertificate;
+  sh:property <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget>,
+    <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> .
+
+<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget> sh:path oa:hasTarget;
+  sh:name "target"@en;
+  sh:description "The identifier of the described resource targetet by the quality certificate."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> sh:path oa:hasBody;
+  sh:name "body"@en;
+  sh:description "The (web)location of the quality certificate."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+hri:aux-RelationshipShape a owl:Ontology;
+  rdfs:label "Relationship"@en;
+  rdfs:comment "Health-RI v2 Relationship"@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Relationship."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-04-23T13:25:25.790Z"^^xsd:dateTime .
+
+hri:RelationshipShape a sh:NodeShape;
+  rdfs:label "Relation"@en;
+  sh:targetClass dcat:Relationship;
+  sh:property <http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole>, <http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> .
+
+<http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole> sh:path dcat:hadRole;
+  sh:name "had role"@en;
+  sh:description "The nature of the relationship, as indicated via a value from the controlled vocabulary."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> sh:path dct:relation;
+  sh:name "relation"@en;
+  sh:description "A resource with a relationship to the cataloged resource."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .

--- a/Formalisation(shacl)/Core/FairDataPointShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/DatasetSeries.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Dataset Series"@en;
   rdfs:comment "Health-RI v2 Dataset Series"@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:15:20.450Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:09.770Z"^^xsd:dateTime .
 
 hri:DatasetSeriesShape a sh:NodeShape;
   rdfs:label "DatasetSeries"@en;
@@ -60,7 +60,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:description "A free-text account of the Dataset Series."@en;
   sh:minCount 1;
@@ -70,7 +70,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:editor dash:TextFieldEditor .
 
 <http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:accrualPeriodicity> sh:path
-    dcterms:accrualPeriodicity;
+    dct:accrualPeriodicity;
   sh:name "frequency"@en;
   sh:description "The frequency at which the Dataset Series is updated."@en;
   sh:maxCount 1;
@@ -78,14 +78,14 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:spatial> sh:path dct:spatial;
   sh:name "geographical coverage"@en;
   sh:description "A geographic region that is covered by the Dataset Series."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:description "The most recent date on which the Dataset Series was changed or modified."@en;
   sh:maxCount 1;
@@ -94,7 +94,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:publisher> sh:path dct:publisher;
   sh:name "publisher"@en;
   sh:description "An entity (organisation) responsible for ensuring the coherency of the Dataset Series."@en;
   sh:maxCount 1;
@@ -102,7 +102,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:description "The date of formal issuance (e.g., publication) of the Dataset Series."@en;
   sh:maxCount 1;
@@ -111,14 +111,14 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:temporal> sh:path dcterms:temporal;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:temporal> sh:path dct:temporal;
   sh:name "temporal coverage"@en;
   sh:description "A temporal period that the Dataset Series covers."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "A name given to the Dataset Series."@en;
   sh:minCount 1;
@@ -130,9 +130,9 @@ hri:DatasetSeriesShape a sh:NodeShape;
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
   rdfs:comment "Excel template for Agent class"@en;
-  dcterms:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
 hri:AgentShape a sh:NodeShape;
   rdfs:label "Agent"@en;
@@ -142,7 +142,7 @@ hri:AgentShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
     <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
   sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -155,10 +155,11 @@ hri:AgentShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
+  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "A unique identifier of the agent."@en;
   sh:minCount 1;
@@ -191,7 +192,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
   sh:maxCount 1;
@@ -211,9 +212,9 @@ hri:AgentShape a sh:NodeShape;
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:15:54.050Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -235,6 +236,7 @@ hri:KindShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
+  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/FairDataPointShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Distribution.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -24,15 +24,16 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix status: <http://publications.europa.eu/resource/authority/distribution-status/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Distribution"@en;
   rdfs:comment "Health-RI v2 Distribution."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:15:38.800Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:14.930Z"^^xsd:dateTime .
 
 hri:DistributionShape a sh:NodeShape;
   rdfs:label "Distribution"@en;
@@ -76,6 +77,8 @@ hri:DistributionShape a sh:NodeShape;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
+  sh:datatype xsd:integer;
+  sh:minExclusive "0";
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
@@ -95,7 +98,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:description "This property can be repeated for parallel language versions of the description."@en;
   sh:nodeKind sh:Literal;
@@ -115,7 +118,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dcterms:format;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dct:format;
   sh:name "format"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -123,14 +126,14 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:description "This property can be repeated if the metadata is provided in multiple languages."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dct:license;
   sh:name "license"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -138,7 +141,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dcterms:conformsTo;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dct:conformsTo;
   sh:name "linked schemas"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -151,7 +154,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
@@ -166,7 +169,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:description "The date the dataset distribution was issued."@en;
   sh:maxCount 1;
@@ -181,7 +184,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:description "A statement that concerns all rights not addressed in fields License or Rights, such as copyright statements. Everything that is not covered with licece"@en;
   sh:minCount 1;
@@ -192,11 +195,28 @@ hri:DistributionShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/DistributionShape#adms:status> sh:path adms:status;
   sh:name "status"@en;
-  sh:description "It MUST take one of the values Completed, Deprecated, Under Development, Withdrawn."@en;
+  sh:description "The status of the distribution in the context of maturity lifecycle."@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
+  sh:in _:genid-abf777c63d194ae894386f41fae78ca033-08A74E602DA6FD81661710C5022150D1;
   dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
+  dash:editor dash:EnumSelectEditor .
+
+_:genid-abf777c63d194ae894386f41fae78ca033-08A74E602DA6FD81661710C5022150D1 rdf:first
+    status:COMPLETED;
+  rdf:rest _:genid-abf777c63d194ae894386f41fae78ca033-E83C8C99E71B76D6EF5473CCF1E1E5E7 .
+
+_:genid-abf777c63d194ae894386f41fae78ca033-E83C8C99E71B76D6EF5473CCF1E1E5E7 rdf:first
+    status:DEVELOP;
+  rdf:rest _:genid-abf777c63d194ae894386f41fae78ca033-1F5CECC6C4A126EF0BDE800009A762D2 .
+
+_:genid-abf777c63d194ae894386f41fae78ca033-1F5CECC6C4A126EF0BDE800009A762D2 rdf:first
+    status:WITHDRAWN;
+  rdf:rest _:genid-abf777c63d194ae894386f41fae78ca033-9179702FD5BE6AD419C642EBA45332AC .
+
+_:genid-abf777c63d194ae894386f41fae78ca033-9179702FD5BE6AD419C642EBA45332AC rdf:first
+    status:DEPRECATED;
+  rdf:rest rdf:nil .
 
 <http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution> sh:path
     dcat:temporalResolution;
@@ -206,7 +226,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "This property can be repeated for parallel language versions of the description."@en;
   sh:minCount 1;
@@ -217,13 +237,13 @@ hri:DistributionShape a sh:NodeShape;
 hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:label "Period of Time"@en;
   rdfs:comment "Health-RI v2 Period of Time"@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:16:09.790Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:13.170Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;
-  sh:targetClass dcterms:PeriodOfTime;
+  sh:targetClass dct:PeriodOfTime;
   sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
 
 <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
@@ -231,7 +251,6 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The end of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -240,16 +259,18 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The start of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-hri:ChecksumShape a owl:Ontology, sh:NodeShape;
+hri:aux-ChecksumShape a owl:Ontology;
   rdfs:label "Checksum"@en;
   rdfs:comment "Health-RI v2 Checksum."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Checksum."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Checksum."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:14:48.980Z"^^xsd:dateTime;
+  dct:modified "2025-04-23T13:25:19.220Z"^^xsd:dateTime .
+
+hri:ChecksumShape a sh:NodeShape;
+  rdfs:label "Checksum"@en;
   sh:targetClass spdx:Checksum;
   sh:property <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:algorithm>, <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:checksumValue> .
 

--- a/Formalisation(shacl)/Core/FairDataPointShape/Resource.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Resource.ttl
@@ -7,10 +7,10 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
-@prefix healthdcatap: <http://example.com/ns/healthdcatap#> .
+@prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,7 +31,7 @@
 hri:ResourceShape a owl:Ontology, sh:NodeShape;
   rdfs:label "Resource"@en;
   rdfs:comment "Health-RI v2 Resource placeholder."@en;
-  dcterms:description "SHACL stub for the Health-RI v2 model for Resource."@en;
+  dct:description "SHACL stub for the Health-RI v2 model for Resource."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-03T13:34:21.800Z"^^xsd:dateTime;
+  dct:modified "2025-04-23T13:25:07.820Z"^^xsd:dateTime;
   sh:targetClass dcat:Resource .

--- a/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
@@ -8,9 +8,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
   rdfs:comment "Excel template for Agent class"@en;
-  dcterms:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
 hri:AgentShape a sh:NodeShape;
   rdfs:label "Agent"@en;
@@ -43,7 +43,7 @@ hri:AgentShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
     <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
   sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -60,13 +60,12 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
   sh:name "identifier"@en;
   sh:description "A unique identifier of the agent."@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:anyURI;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextAreaEditor .
 
@@ -94,7 +93,7 @@ hri:AgentShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dcterms:type;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
   sh:name "type"@en;
   sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
   sh:maxCount 1;

--- a/Formalisation(shacl)/Core/PiecesShape/Attribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Attribution.ttl
@@ -32,7 +32,7 @@ hri:aux-AttributionShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Attribution"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Attribution."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-22T09:24:27.760Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:20.480Z"^^xsd:dateTime .
 
 hri:AttributionShape a sh:NodeShape;
   rdfs:label "Attribution"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -30,9 +30,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Catalog"@en;
   rdfs:comment "Health-RI v2 Catalog."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Catalog."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Catalog."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:14:36.480Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:16.780Z"^^xsd:dateTime .
 
 hri:CatalogShape a sh:NodeShape;
   rdfs:label "Catalog"@en;
@@ -68,7 +68,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dcterms:creator;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dct:creator;
   sh:name "creator"@en;
   sh:node hri:AgentShape;
   dash:viewer dash:DetailsViewer;
@@ -77,21 +77,21 @@ hri:CatalogShape a sh:NodeShape;
 <http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset> sh:path dcat:dataset;
   sh:name "dataset"@en .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:minCount 1;
   sh:nodeKind sh:Literal;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextAreaEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dct:spatial;
   sh:name "geographical coverage"@en;
   sh:description "The EU Vocabularies Name Authority Lists must be used for continents, countries and places that are in those lists; if a particular location is not in one of the mentioned Named Authority Lists, Geonames URIs must be used. For districts or neighbourhoods in NL, the Dutch vocab can be used."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dcterms:hasPart;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dct:hasPart;
   sh:name "has part"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -104,27 +104,27 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dct:license;
   sh:name "licence"@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dct:publisher;
   sh:name "publisher"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -136,14 +136,14 @@ hri:CatalogShape a sh:NodeShape;
   sh:name "record"@en;
   sh:class dcat:CatalogRecord .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
@@ -156,7 +156,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dcterms:temporal;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dct:temporal;
   sh:name "temporal coverage"@en;
   sh:node hri:PeriodOfTimeShape;
   dash:viewer dash:DetailsViewer;
@@ -169,7 +169,7 @@ hri:CatalogShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:minCount 1;
   sh:nodeKind sh:Literal;

--- a/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
@@ -32,7 +32,7 @@ hri:aux-ChecksumShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Checksum."@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Checksum."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-22T09:24:32.200Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:19.220Z"^^xsd:dateTime .
 
 hri:ChecksumShape a sh:NodeShape;
   rdfs:label "Checksum"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -30,9 +30,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "DataService"@en;
   rdfs:comment "Health-RI v2 DataService."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for DataService."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for DataService."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-04-22T14:37:03.100Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:32.440Z"^^xsd:dateTime .
 
 hri:DataServiceShape a sh:NodeShape;
   rdfs:label "DataService"@en;
@@ -50,7 +50,7 @@ hri:DataServiceShape a sh:NodeShape;
     <http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher>, <http://data.health-ri.nl/core/p2/DataServiceShape#dcat:servesDataset>,
     <http://data.health-ri.nl/core/p2/DataServiceShape#dcat:theme>, <http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:accessRights> sh:path dcterms:accessRights;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:accessRights> sh:path dct:accessRights;
   sh:name "Access Rights"@en;
   sh:description "Information that indicates whether the Dataset is publicly accessible, has access restrictions or is not public. Use one of the following values (:public, :restricted, :non-public)."@en;
   sh:minCount 1;
@@ -67,7 +67,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:conformsTo> sh:path dcterms:conformsTo;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:conformsTo> sh:path dct:conformsTo;
   sh:name "application profile"@en;
   sh:description "The standards referred here SHOULD describe the Data Service and not the data it serves. The latter is provided by the dataset with which this Data Service is connected. For instance the data service adheres to the OGC WFS API standard, while the associated dataset adheres to the INSPIRE Address data model."@en;
   sh:nodeKind sh:IRI;
@@ -83,19 +83,19 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:creator> sh:path dcterms:creator;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:creator> sh:path dct:creator;
   sh:name "creator"@en;
   sh:node hri:AgentShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:description> sh:path dct:description;
   sh:name "Description"@en;
   sh:description "A free-text account of the Data Service."@en;
   sh:minCount 1;
@@ -122,7 +122,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:format> sh:path dcterms:format;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:format> sh:path dct:format;
   sh:name "format"@en;
   sh:description "The structure that can be returned by querying the endpointURL."@en;
   sh:nodeKind sh:IRI;
@@ -135,12 +135,11 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:identifier> sh:path dcterms:identifier;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:identifier> sh:path dct:identifier;
   sh:name "Identifier"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:anyURI;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
@@ -158,13 +157,13 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:license> sh:path dct:license;
   sh:name "License"@en;
   sh:description "A licence under which the Data service is made available."@en;
   sh:minCount 1;
@@ -173,7 +172,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
@@ -186,7 +185,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:publisher> sh:path dct:publisher;
   sh:name "Publisher"@en;
   sh:description "An entity (organisation) responsible for making the Data Service available."@en;
   sh:minCount 1;
@@ -210,7 +209,7 @@ hri:DataServiceShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DataServiceShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "A name given to the Data Service."@en;
   sh:minCount 1;

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -70,17 +70,17 @@ hri:DatasetShape a owl:Ontology, sh:NodeShape;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:fbdd823e254b47229244b90c82aab43d2;
+  sh:in _:72a01c3567454b399f90c065880e6ba32;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:fbdd823e254b47229244b90c82aab43d2 rdf:first eu:PUBLIC;
-  rdf:rest _:fbdd823e254b47229244b90c82aab43d3 .
+_:72a01c3567454b399f90c065880e6ba32 rdf:first eu:PUBLIC;
+  rdf:rest _:72a01c3567454b399f90c065880e6ba33 .
 
-_:fbdd823e254b47229244b90c82aab43d3 rdf:first eu:RESTRICTED;
-  rdf:rest _:fbdd823e254b47229244b90c82aab43d4 .
+_:72a01c3567454b399f90c065880e6ba33 rdf:first eu:RESTRICTED;
+  rdf:rest _:72a01c3567454b399f90c065880e6ba34 .
 
-_:fbdd823e254b47229244b90c82aab43d4 rdf:first eu:NON_PUBLIC;
+_:72a01c3567454b399f90c065880e6ba34 rdf:first eu:NON_PUBLIC;
   rdf:rest rdf:nil .
 
 <http://data.health-ri.nl/core/p2/DatasetShape#analytics> sh:path healthdcatap:analytics;
@@ -203,7 +203,6 @@ _:fbdd823e254b47229244b90c82aab43d4 rdf:first eu:NON_PUBLIC;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:anyURI;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -30,9 +30,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Dataset Series"@en;
   rdfs:comment "Health-RI v2 Dataset Series"@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:15:20.450Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:09.770Z"^^xsd:dateTime .
 
 hri:DatasetSeriesShape a sh:NodeShape;
   rdfs:label "DatasetSeries"@en;
@@ -59,7 +59,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:description "A free-text account of the Dataset Series."@en;
   sh:minCount 1;
@@ -69,7 +69,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:editor dash:TextFieldEditor .
 
 <http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:accrualPeriodicity> sh:path
-    dcterms:accrualPeriodicity;
+    dct:accrualPeriodicity;
   sh:name "frequency"@en;
   sh:description "The frequency at which the Dataset Series is updated."@en;
   sh:maxCount 1;
@@ -77,14 +77,14 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:spatial> sh:path dcterms:spatial;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:spatial> sh:path dct:spatial;
   sh:name "geographical coverage"@en;
   sh:description "A geographic region that is covered by the Dataset Series."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:description "The most recent date on which the Dataset Series was changed or modified."@en;
   sh:maxCount 1;
@@ -93,7 +93,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:publisher> sh:path dcterms:publisher;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:publisher> sh:path dct:publisher;
   sh:name "publisher"@en;
   sh:description "An entity (organisation) responsible for ensuring the coherency of the Dataset Series."@en;
   sh:maxCount 1;
@@ -101,7 +101,7 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:description "The date of formal issuance (e.g., publication) of the Dataset Series."@en;
   sh:maxCount 1;
@@ -110,14 +110,14 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:temporal> sh:path dcterms:temporal;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:temporal> sh:path dct:temporal;
   sh:name "temporal coverage"@en;
   sh:description "A temporal period that the Dataset Series covers."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DatasetSeriesShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "A name given to the Dataset Series."@en;
   sh:minCount 1;

--- a/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Distribution"@en;
   rdfs:comment "Health-RI v2 Distribution."@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-20T13:51:38.610Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:14.930Z"^^xsd:dateTime .
 
 hri:DistributionShape a sh:NodeShape;
   rdfs:label "Distribution"@en;
@@ -77,6 +77,8 @@ hri:DistributionShape a sh:NodeShape;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
+  sh:datatype xsd:integer;
+  sh:minExclusive "0";
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
@@ -96,7 +98,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dcterms:description;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dct:description;
   sh:name "description"@en;
   sh:description "This property can be repeated for parallel language versions of the description."@en;
   sh:nodeKind sh:Literal;
@@ -116,7 +118,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dcterms:format;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dct:format;
   sh:name "format"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -124,14 +126,14 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dcterms:language;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dct:language;
   sh:name "language"@en;
   sh:description "This property can be repeated if the metadata is provided in multiple languages."@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dcterms:license;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dct:license;
   sh:name "license"@en;
   sh:minCount 1;
   sh:maxCount 1;
@@ -139,7 +141,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dcterms:conformsTo;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dct:conformsTo;
   sh:name "linked schemas"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
@@ -152,7 +154,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dcterms:modified;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dct:modified;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
@@ -167,7 +169,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dcterms:issued;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dct:issued;
   sh:name "release date"@en;
   sh:description "The date the dataset distribution was issued."@en;
   sh:maxCount 1;
@@ -182,7 +184,7 @@ hri:DistributionShape a sh:NodeShape;
   dash:viewer dash:DetailsViewer;
   dash:editor dash:BlankNodeEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dcterms:rights;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dct:rights;
   sh:name "rights"@en;
   sh:description "A statement that concerns all rights not addressed in fields License or Rights, such as copyright statements. Everything that is not covered with licece"@en;
   sh:minCount 1;
@@ -196,20 +198,20 @@ hri:DistributionShape a sh:NodeShape;
   sh:description "The status of the distribution in the context of maturity lifecycle."@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:ab6d3359c1d442dc81fece41d5ed6fc92;
+  sh:in _:3019d1e8b7544a8b8553c093971cdbd92;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:ab6d3359c1d442dc81fece41d5ed6fc92 rdf:first status:COMPLETED;
-  rdf:rest _:ab6d3359c1d442dc81fece41d5ed6fc93 .
+_:3019d1e8b7544a8b8553c093971cdbd92 rdf:first status:COMPLETED;
+  rdf:rest _:3019d1e8b7544a8b8553c093971cdbd93 .
 
-_:ab6d3359c1d442dc81fece41d5ed6fc93 rdf:first status:DEVELOP;
-  rdf:rest _:ab6d3359c1d442dc81fece41d5ed6fc94 .
+_:3019d1e8b7544a8b8553c093971cdbd93 rdf:first status:DEVELOP;
+  rdf:rest _:3019d1e8b7544a8b8553c093971cdbd94 .
 
-_:ab6d3359c1d442dc81fece41d5ed6fc94 rdf:first status:WITHDRAWN;
-  rdf:rest _:ab6d3359c1d442dc81fece41d5ed6fc95 .
+_:3019d1e8b7544a8b8553c093971cdbd94 rdf:first status:WITHDRAWN;
+  rdf:rest _:3019d1e8b7544a8b8553c093971cdbd95 .
 
-_:ab6d3359c1d442dc81fece41d5ed6fc95 rdf:first status:DEPRECATED;
+_:3019d1e8b7544a8b8553c093971cdbd95 rdf:first status:DEPRECATED;
   rdf:rest rdf:nil .
 
 <http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution> sh:path
@@ -220,7 +222,7 @@ _:ab6d3359c1d442dc81fece41d5ed6fc95 rdf:first status:DEPRECATED;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dcterms:title;
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dct:title;
   sh:name "title"@en;
   sh:description "This property can be repeated for parallel language versions of the description."@en;
   sh:minCount 1;

--- a/Formalisation(shacl)/Core/PiecesShape/Identifier.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Identifier.ttl
@@ -32,7 +32,7 @@ hri:aux-IdentifierShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Identifier"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Identifier."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-22T09:24:48.010Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:22.090Z"^^xsd:dateTime .
 
 hri:IdentifierShape a sh:NodeShape;
   rdfs:label "Identifier"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
@@ -8,9 +8,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,9 +31,9 @@
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
-  dcterms:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-17T12:58:47.890Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
@@ -7,9 +7,9 @@
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
 @prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -30,13 +30,13 @@
 hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:label "Period of Time"@en;
   rdfs:comment "Health-RI v2 Period of Time"@en;
-  dcterms:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-13T12:16:09.790Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:13.170Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;
-  sh:targetClass dcterms:PeriodOfTime;
+  sh:targetClass dct:PeriodOfTime;
   sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
 
 <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
@@ -44,7 +44,6 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The end of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -53,6 +52,5 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The start of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .

--- a/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
@@ -32,7 +32,7 @@ hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Period of Time"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:13.170Z"^^xsd:dateTime .
+  dct:modified "2025-04-24T08:40:25.850Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;
@@ -44,6 +44,7 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The end of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -52,5 +53,6 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:description "The start of the period."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .

--- a/Formalisation(shacl)/Core/PiecesShape/QualityCertificate.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/QualityCertificate.ttl
@@ -34,7 +34,7 @@ hri:aux-QualityCertificateShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Quality Certificate"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Quality Certificate."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-22T09:24:55.780Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:27.610Z"^^xsd:dateTime .
 
 hri:QualityCertificateShape a sh:NodeShape;
   rdfs:label "Quality Certificate"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Relationship.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Relationship.ttl
@@ -32,7 +32,7 @@ hri:aux-RelationshipShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Relationship"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Relationship."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-22T09:25:05.120Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:25.790Z"^^xsd:dateTime .
 
 hri:RelationshipShape a sh:NodeShape;
   rdfs:label "Relation"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
@@ -7,10 +7,10 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
-@prefix healthdcatap: <http://example.com/ns/healthdcatap#> .
+@prefix healthdcatap: <http://healthdataportal.eu/ns/health#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix euvoc: <http://publications.europa.eu/ontology/euvoc#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
@@ -31,7 +31,7 @@
 hri:ResourceShape a owl:Ontology, sh:NodeShape;
   rdfs:label "Resource"@en;
   rdfs:comment "Health-RI v2 Resource placeholder."@en;
-  dcterms:description "SHACL stub for the Health-RI v2 model for Resource."@en;
+  dct:description "SHACL stub for the Health-RI v2 model for Resource."@en;
   owl:versionInfo "0.1";
-  dcterms:modified "2025-03-03T13:34:21.800Z"^^xsd:dateTime;
+  dct:modified "2025-04-23T13:25:07.820Z"^^xsd:dateTime;
   sh:targetClass dcat:Resource .


### PR DESCRIPTION
Revert anyUri to literal
Fix: namesspace for dcterms -> dct

## Summary by Sourcery

Replace anyUri with literal and correct namespace for dcterms in multiple SHACL shape files

New Features:
- Update SHACL shape files to use literal instead of anyUri

Bug Fixes:
- Correct namespace from dcterms to dct in SHACL shape files