### PR TITLE
feat: remove default values that interfere with fdp validation

### DIFF
--- a/Formalisation(shacl)/Core/FairDataPointShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Catalog.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
@@ -200,12 +200,11 @@ hri:AgentShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
   sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -263,7 +262,7 @@ hri:KindShapeKindShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Kind."@en;
   dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -280,12 +279,11 @@ hri:KindShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
   sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -303,7 +301,7 @@ hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Period of Time"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-24T08:40:25.850Z"^^xsd:dateTime .
+  dct:modified "2025-04-24T09:10:17.860Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;

--- a/Formalisation(shacl)/Core/FairDataPointShape/DataService.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/DataService.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
@@ -241,12 +241,11 @@ hri:AgentShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
   sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -304,7 +303,7 @@ hri:KindShapeKindShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Kind."@en;
   dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -321,12 +320,11 @@ hri:KindShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
   sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/FairDataPointShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Dataset.ttl
@@ -71,19 +71,19 @@ hri:DatasetShape a owl:Ontology, sh:NodeShape;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:genid-d2c31ce987834c0fba07706c044768d415-4FBC5B690ADE17A88B045B7FA0F62F57;
+  sh:in _:genid-da6932df208249999cca8f74f47df74815-BF6149BFECB8E84A2A1B741A5BC0B788;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:genid-d2c31ce987834c0fba07706c044768d415-4FBC5B690ADE17A88B045B7FA0F62F57 rdf:first
+_:genid-da6932df208249999cca8f74f47df74815-BF6149BFECB8E84A2A1B741A5BC0B788 rdf:first
     eu:PUBLIC;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d415-AD09BC4120CB46D7443C455C307C6169 .
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74815-9E62FD79D9F37683EED6986B00D42809 .
 
-_:genid-d2c31ce987834c0fba07706c044768d415-AD09BC4120CB46D7443C455C307C6169 rdf:first
+_:genid-da6932df208249999cca8f74f47df74815-9E62FD79D9F37683EED6986B00D42809 rdf:first
     eu:RESTRICTED;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d415-1B2498101F60F5A420D976B7FDABF6C9 .
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74815-54095F1B2782AEC4774D363AA503AFE3 .
 
-_:genid-d2c31ce987834c0fba07706c044768d415-1B2498101F60F5A420D976B7FDABF6C9 rdf:first
+_:genid-da6932df208249999cca8f74f47df74815-54095F1B2782AEC4774D363AA503AFE3 rdf:first
     eu:NON_PUBLIC;
   rdf:rest rdf:nil .
 
@@ -234,9 +234,8 @@ _:genid-d2c31ce987834c0fba07706c044768d415-1B2498101F60F5A420D976B7FDABF6C9 rdf:
 
 <http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dpv:hasLegalBasis;
   sh:name "legal basis"@en;
-  sh:description "The legal basis used to justify processing of personal data. The legal basis can be provided as a value from the dpv taxonomy"@en;
+  sh:description "The legal basis used to justify processing of personal data. The legal basis can be provided as a value from the dpv taxonomy and should be provided via IRI, for example https://w3id.org/dpv#Consent"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -295,9 +294,8 @@ _:genid-d2c31ce987834c0fba07706c044768d415-1B2498101F60F5A420D976B7FDABF6C9 rdf:
 
 <http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dpv:hasPersonalData;
   sh:name "personal data"@en;
-  sh:description "Key elements that represent an individual in the dataset. Values can be picked from the dpv taxonomy."@en;
+  sh:description "Key elements that represent an individual in the dataset. Values can be picked from the dpv taxonomy, for example https://w3id.org/dpv/dpv-pd#Gender"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv/dpv-pd#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 
@@ -320,9 +318,8 @@ _:genid-d2c31ce987834c0fba07706c044768d415-1B2498101F60F5A420D976B7FDABF6C9 rdf:
 
 <http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dpv:hasPurpose;
   sh:name "purpose"@en;
-  sh:description "Indicates association with Purpose. One (or many) category or sub-category of the purposes can be chosen from the taxonomy provided by dpv."@en;
+  sh:description "Indicates association with Purpose. One (or many) category or sub-category of the purposes can be chosen from the taxonomy provided by dpv and should be provided via IRI, for example https://w3id.org/dpv#ScientificResearch"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 
@@ -474,12 +471,11 @@ hri:AgentShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
   sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -537,7 +533,7 @@ hri:KindShapeKindShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Kind."@en;
   dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -554,12 +550,11 @@ hri:KindShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
   sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -601,119 +596,3 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:datatype xsd:dateTime;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
-
-hri:aux-AttributionShape a owl:Ontology;
-  rdfs:label "Attribution"@en;
-  rdfs:comment "Health-RI v2 Attribution"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Attribution."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:20.480Z"^^xsd:dateTime .
-
-hri:AttributionShape a sh:NodeShape;
-  rdfs:label "Attribution"@en;
-  sh:targetClass prov:Attribution;
-  sh:property <http://data.health-ri.nl/core/p2/AttributionShape#prov:agent>, <http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> .
-
-<http://data.health-ri.nl/core/p2/AttributionShape#prov:agent> sh:path prov:agent;
-  sh:name "agent"@en;
-  sh:description "The agent that has a specific role with the described resource."@en;
-  sh:maxCount 1;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> sh:path dcat:hadRole;
-  sh:name "role"@en;
-  sh:description "The nature of the relationship between the agent and the described resource, as indicated by a value from the controlled vocabulary."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
-
-hri:aux-IdentifierShape a owl:Ontology;
-  rdfs:label "Identifier"@en;
-  rdfs:comment "Health-RI v2 Identifier"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Identifier."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-30T10:51:11.420Z"^^xsd:dateTime .
-
-hri:IdentifierShape a sh:NodeShape;
-  rdfs:label "Identifier"@en;
-  sh:targetClass adms:Identifier;
-  sh:property <http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation>, <http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> .
-
-<http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation> sh:path skos:notation;
-  sh:name "notation"@en;
-  sh:description "A string that is an identifier in the context of the identifier scheme referenced by its datatype."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> sh:path adms:schemaAgency;
-  sh:name "schema agency"@en;
-  sh:description "The name of the agency that issued the identifier."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-hri:aux-QualityCertificateShape a owl:Ontology;
-  rdfs:label "Quality Certificate"@en;
-  rdfs:comment "Health-RI v2 Quality Certificate"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Quality Certificate."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-24T11:33:11.140Z"^^xsd:dateTime .
-
-hri:QualityCertificateShape a sh:NodeShape;
-  rdfs:label "Quality Certificate"@en;
-  sh:targetClass dqv:QualityCertificate;
-  sh:property <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget>,
-    <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> .
-
-<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget> sh:path oa:hasTarget;
-  sh:name "target"@en;
-  sh:description "The identifier of the described resource targetet by the quality certificate."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> sh:path oa:hasBody;
-  sh:name "body"@en;
-  sh:description "The (web)location of the quality certificate."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-hri:aux-RelationshipShape a owl:Ontology;
-  rdfs:label "Relationship"@en;
-  rdfs:comment "Health-RI v2 Relationship"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Relationship."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-30T10:50:43.190Z"^^xsd:dateTime .
-
-hri:RelationshipShape a sh:NodeShape;
-  rdfs:label "Relation"@en;
-  sh:targetClass dcat:Relationship;
-  sh:property <http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole>, <http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> .
-
-<http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole> sh:path dcat:hadRole;
-  sh:name "had role"@en;
-  sh:description "The nature of the relationship, as indicated via a value from the controlled vocabulary."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> sh:path dct:relation;
-  sh:name "relation"@en;
-  sh:description "A resource with a relationship to the cataloged resource."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .

--- a/Formalisation(shacl)/Core/FairDataPointShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/DatasetSeries.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
@@ -150,12 +150,11 @@ hri:AgentShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
   sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -213,7 +212,7 @@ hri:KindShapeKindShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Kind."@en;
   dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -230,12 +229,11 @@ hri:KindShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
   sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/FairDataPointShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Distribution.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,6 +19,7 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
@@ -25,15 +27,13 @@
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix status: <http://publications.europa.eu/resource/authority/distribution-status/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Distribution"@en;
   rdfs:comment "Health-RI v2 Distribution."@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:14.930Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T05:12:16.430Z"^^xsd:dateTime .
 
 hri:DistributionShape a sh:NodeShape;
   rdfs:label "Distribution"@en;
@@ -198,23 +198,23 @@ hri:DistributionShape a sh:NodeShape;
   sh:description "The status of the distribution in the context of maturity lifecycle."@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:genid-6a604983e8664d37a1ce648860a6873d33-B396BA40C83BE1233A13144FBEBE93C4;
+  sh:in _:genid-da6932df208249999cca8f74f47df74831-B8C0D19C0D0A0AADD3F5BBB535A1757B;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:genid-6a604983e8664d37a1ce648860a6873d33-B396BA40C83BE1233A13144FBEBE93C4 rdf:first
+_:genid-da6932df208249999cca8f74f47df74831-B8C0D19C0D0A0AADD3F5BBB535A1757B rdf:first
     status:COMPLETED;
-  rdf:rest _:genid-6a604983e8664d37a1ce648860a6873d33-442A834CC308C8C0D654E85281B9F6EB .
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74831-BC386D931CCC43EB5DCD940CDE56E1B4 .
 
-_:genid-6a604983e8664d37a1ce648860a6873d33-442A834CC308C8C0D654E85281B9F6EB rdf:first
+_:genid-da6932df208249999cca8f74f47df74831-BC386D931CCC43EB5DCD940CDE56E1B4 rdf:first
     status:DEVELOP;
-  rdf:rest _:genid-6a604983e8664d37a1ce648860a6873d33-42082B56D9E213FC9A7E6F60C32EDE03 .
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74831-05FAACE1BBFD2C2DEC85572B168435DA .
 
-_:genid-6a604983e8664d37a1ce648860a6873d33-42082B56D9E213FC9A7E6F60C32EDE03 rdf:first
+_:genid-da6932df208249999cca8f74f47df74831-05FAACE1BBFD2C2DEC85572B168435DA rdf:first
     status:WITHDRAWN;
-  rdf:rest _:genid-6a604983e8664d37a1ce648860a6873d33-92A8D1416B18A12FB6A5198CD2A204AE .
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74831-AD0B8CAF3108E4231B2E6E045AC9894E .
 
-_:genid-6a604983e8664d37a1ce648860a6873d33-92A8D1416B18A12FB6A5198CD2A204AE rdf:first
+_:genid-da6932df208249999cca8f74f47df74831-AD0B8CAF3108E4231B2E6E045AC9894E rdf:first
     status:DEPRECATED;
   rdf:rest rdf:nil .
 
@@ -239,7 +239,7 @@ hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:comment "Health-RI v2 Period of Time"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-24T08:40:25.850Z"^^xsd:dateTime .
+  dct:modified "2025-04-24T09:10:17.860Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;

--- a/Formalisation(shacl)/Core/FairDataPointShape/Resource.ttl
+++ b/Formalisation(shacl)/Core/FairDataPointShape/Resource.ttl
@@ -4,6 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -19,14 +20,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:ResourceShape a owl:Ontology, sh:NodeShape;
   rdfs:label "Resource"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Agent.ttl
@@ -4,6 +4,7 @@
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -19,14 +20,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:AgentShapeAgentShape a owl:Ontology;
   rdfs:label "Agent class"@en;
@@ -51,12 +51,11 @@ hri:AgentShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
   sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/Attribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Attribution.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-AttributionShape a owl:Ontology;
   rdfs:label "Attribution"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Catalog"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Checksum.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-ChecksumShape a owl:Ontology;
   rdfs:label "Checksum"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "DataService"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -69,17 +69,17 @@ hri:DatasetShape a owl:Ontology, sh:NodeShape;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:f7895198615b4613985abdc7f240e94a6;
+  sh:in _:c43d47d21f8e45a0a6b80a39c0fca5706;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:f7895198615b4613985abdc7f240e94a6 rdf:first eu:PUBLIC;
-  rdf:rest _:f7895198615b4613985abdc7f240e94a7 .
+_:c43d47d21f8e45a0a6b80a39c0fca5706 rdf:first eu:PUBLIC;
+  rdf:rest _:c43d47d21f8e45a0a6b80a39c0fca5707 .
 
-_:f7895198615b4613985abdc7f240e94a7 rdf:first eu:RESTRICTED;
-  rdf:rest _:f7895198615b4613985abdc7f240e94a8 .
+_:c43d47d21f8e45a0a6b80a39c0fca5707 rdf:first eu:RESTRICTED;
+  rdf:rest _:c43d47d21f8e45a0a6b80a39c0fca5708 .
 
-_:f7895198615b4613985abdc7f240e94a8 rdf:first eu:NON_PUBLIC;
+_:c43d47d21f8e45a0a6b80a39c0fca5708 rdf:first eu:NON_PUBLIC;
   rdf:rest rdf:nil .
 
 <http://data.health-ri.nl/core/p2/DatasetShape#analytics> sh:path healthdcatap:analytics;
@@ -229,9 +229,8 @@ _:f7895198615b4613985abdc7f240e94a8 rdf:first eu:NON_PUBLIC;
 
 <http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dpv:hasLegalBasis;
   sh:name "legal basis"@en;
-  sh:description "The legal basis used to justify processing of personal data. The legal basis can be provided as a value from the dpv taxonomy"@en;
+  sh:description "The legal basis used to justify processing of personal data. The legal basis can be provided as a value from the dpv taxonomy and should be provided via IRI, for example https://w3id.org/dpv#Consent"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
@@ -290,9 +289,8 @@ _:f7895198615b4613985abdc7f240e94a8 rdf:first eu:NON_PUBLIC;
 
 <http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dpv:hasPersonalData;
   sh:name "personal data"@en;
-  sh:description "Key elements that represent an individual in the dataset. Values can be picked from the dpv taxonomy."@en;
+  sh:description "Key elements that represent an individual in the dataset. Values can be picked from the dpv taxonomy, for example https://w3id.org/dpv/dpv-pd#Gender"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv/dpv-pd#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 
@@ -315,9 +313,8 @@ _:f7895198615b4613985abdc7f240e94a8 rdf:first eu:NON_PUBLIC;
 
 <http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dpv:hasPurpose;
   sh:name "purpose"@en;
-  sh:description "Indicates association with Purpose. One (or many) category or sub-category of the purposes can be chosen from the taxonomy provided by dpv."@en;
+  sh:description "Indicates association with Purpose. One (or many) category or sub-category of the purposes can be chosen from the taxonomy provided by dpv and should be provided via IRI, for example https://w3id.org/dpv#ScientificResearch"@en;
   sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
   dash:viewer dash:LabelViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,14 +19,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Dataset Series"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,6 +19,7 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
@@ -25,15 +27,13 @@
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix status: <http://publications.europa.eu/resource/authority/distribution-status/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 <https://data.sparna.fr/shapes-example#> a owl:Ontology;
   rdfs:label "Distribution"@en;
   rdfs:comment "Health-RI v2 Distribution."@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Distribution."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:14.930Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T05:12:16.430Z"^^xsd:dateTime .
 
 hri:DistributionShape a sh:NodeShape;
   rdfs:label "Distribution"@en;
@@ -78,7 +78,7 @@ hri:DistributionShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:integer;
-  sh:minExclusive "0";
+  sh:minExclusive 0;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
@@ -198,20 +198,20 @@ hri:DistributionShape a sh:NodeShape;
   sh:description "The status of the distribution in the context of maturity lifecycle."@en;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
-  sh:in _:99d14728f28047199352ee56ba3ec33e2;
+  sh:in _:c43d47d21f8e45a0a6b80a39c0fca5702;
   dash:viewer dash:URIViewer;
   dash:editor dash:EnumSelectEditor .
 
-_:99d14728f28047199352ee56ba3ec33e2 rdf:first status:COMPLETED;
-  rdf:rest _:99d14728f28047199352ee56ba3ec33e3 .
+_:c43d47d21f8e45a0a6b80a39c0fca5702 rdf:first status:COMPLETED;
+  rdf:rest _:c43d47d21f8e45a0a6b80a39c0fca5703 .
 
-_:99d14728f28047199352ee56ba3ec33e3 rdf:first status:DEVELOP;
-  rdf:rest _:99d14728f28047199352ee56ba3ec33e4 .
+_:c43d47d21f8e45a0a6b80a39c0fca5703 rdf:first status:DEVELOP;
+  rdf:rest _:c43d47d21f8e45a0a6b80a39c0fca5704 .
 
-_:99d14728f28047199352ee56ba3ec33e4 rdf:first status:WITHDRAWN;
-  rdf:rest _:99d14728f28047199352ee56ba3ec33e5 .
+_:c43d47d21f8e45a0a6b80a39c0fca5704 rdf:first status:WITHDRAWN;
+  rdf:rest _:c43d47d21f8e45a0a6b80a39c0fca5705 .
 
-_:99d14728f28047199352ee56ba3ec33e5 rdf:first status:DEPRECATED;
+_:c43d47d21f8e45a0a6b80a39c0fca5705 rdf:first status:DEPRECATED;
   rdf:rest rdf:nil .
 
 <http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution> sh:path

--- a/Formalisation(shacl)/Core/PiecesShape/Identifier.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Identifier.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,21 +19,20 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-IdentifierShape a owl:Ontology;
   rdfs:label "Identifier"@en;
   rdfs:comment "Health-RI v2 Identifier"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Identifier."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:22.090Z"^^xsd:dateTime .
+  dct:modified "2025-04-30T10:51:11.420Z"^^xsd:dateTime .
 
 hri:IdentifierShape a sh:NodeShape;
   rdfs:label "Identifier"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Kind.ttl
@@ -4,6 +4,7 @@
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -19,21 +20,20 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:KindShapeKindShape a owl:Ontology;
   rdfs:label "Kind"@en;
   rdfs:comment "Health-RI v2 Kind."@en;
   dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
 
 hri:KindShape a sh:NodeShape;
   rdfs:label "Kind"@en;
@@ -50,12 +50,11 @@ hri:KindShape a sh:NodeShape;
 
 <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
   sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
   sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,21 +19,20 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-PeriodOfTimeShape a owl:Ontology;
   rdfs:label "Period of Time"@en;
   rdfs:comment "Health-RI v2 Period of Time"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-24T08:40:25.850Z"^^xsd:dateTime .
+  dct:modified "2025-04-24T09:10:17.860Z"^^xsd:dateTime .
 
 hri:PeriodOfTimeShape a sh:NodeShape;
   rdfs:label "Period of Time"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/QualityCertificate.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/QualityCertificate.ttl
@@ -4,6 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -20,21 +21,20 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-QualityCertificateShape a owl:Ontology;
   rdfs:label "Quality Certificate"@en;
   rdfs:comment "Health-RI v2 Quality Certificate"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Quality Certificate."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:27.610Z"^^xsd:dateTime .
+  dct:modified "2025-04-24T11:33:11.140Z"^^xsd:dateTime .
 
 hri:QualityCertificateShape a sh:NodeShape;
   rdfs:label "Quality Certificate"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Relationship.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Relationship.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -18,21 +19,20 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:aux-RelationshipShape a owl:Ontology;
   rdfs:label "Relationship"@en;
   rdfs:comment "Health-RI v2 Relationship"@en;
   dct:description "SHACL definitions for the Health-RI v2 model for Relationship."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:25.790Z"^^xsd:dateTime .
+  dct:modified "2025-04-30T12:55:04.260Z"^^xsd:dateTime .
 
 hri:RelationshipShape a sh:NodeShape;
   rdfs:label "Relation"@en;

--- a/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Resource.ttl
@@ -4,6 +4,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -19,14 +20,13 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 
 hri:ResourceShape a owl:Ontology, sh:NodeShape;
   rdfs:label "Resource"@en;

--- a/Formalisation(shacl)/Core/ValidationShape/HRI-Datamodel-shapes.ttl
+++ b/Formalisation(shacl)/Core/ValidationShape/HRI-Datamodel-shapes.ttl
@@ -1,9 +1,9 @@
 @prefix schema: <http://schema.org/> .
 @prefix spdx: <http://spdx.org/rdf/terms#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skosthes: <http://purl.org/iso25964/skos-thes#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix example: <https://data.sparna.fr/shapes-example/> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
@@ -19,72 +19,210 @@
 @prefix adms: <http://www.w3.org/ns/adms#> .
 @prefix dcatap: <http://data.europa.eu/r5r/> .
 @prefix org: <http://www.w3.org/ns/org#> .
+@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
 @prefix xls2rdf: <https://xls2rdf.sparna.fr/vocabulary#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix shacl-play: <https://shacl-play.sparna.fr/ontology#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dash: <http://datashapes.org/dash#> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix skosxl: <http://www.w3.org/2008/05/skos-xl#> .
+@prefix disco: <http://rdf-vocabulary.ddialliance.org/discovery#> .
 @prefix dqv: <http://www.w3.org/ns/dqv#> .
 @prefix oa: <http://www.w3.org/ns/oa#> .
-@prefix status: <http://publications.europa.eu/resource/authority/distribution-status/> .
 @prefix dpv: <https://w3id.org/dpv#> .
-@prefix efo: <http://www.ebi.ac.uk/efo/efo.owl/> .
 @prefix eu: <http://publications.europa.eu/resource/authority/access-right/> .
 @prefix dpv-pd: <https://w3id.org/dpv/dpv-pd#> .
+@prefix status: <http://publications.europa.eu/resource/authority/distribution-status/> .
 
-hri:KindShapeKindShape a owl:Ontology;
-  rdfs:label "Kind"@en;
-  rdfs:comment "Health-RI v2 Kind."@en;
-  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+<https://data.sparna.fr/shapes-example#> a owl:Ontology;
+  rdfs:label "Catalog"@en, "Dataset Series"@en, "Distribution"@en, "DataService"@en;
+  rdfs:comment "Health-RI v2 Catalog."@en, "Health-RI v2 Dataset Series"@en, "Health-RI v2 Distribution."@en,
+    "Health-RI v2 DataService."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Catalog."@en, "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en,
+    "SHACL definitions for the Health-RI v2 model for Distribution."@en, "SHACL definitions for the Health-RI v2 model for DataService."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:11.960Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:16.780Z"^^xsd:dateTime, "2025-04-23T13:25:09.770Z"^^xsd:dateTime,
+    "2025-05-02T05:12:16.430Z"^^xsd:dateTime, "2025-04-23T13:25:32.440Z"^^xsd:dateTime .
 
-hri:KindShape a sh:NodeShape;
-  rdfs:label "Kind"@en;
-  sh:targetClass vcard:Kind;
-  sh:property <http://data.health-ri.nl/core/p2/KindShape#vcard:hasURL>, <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail>,
-    <http://data.health-ri.nl/core/p2/KindShape#vcard:fn> .
+hri:CatalogShape a sh:NodeShape;
+  rdfs:label "Catalog"@en;
+  sh:targetClass dcat:Catalog;
+  sh:property <http://data.health-ri.nl/core/p2/CatalogShape#dcatap:applicableLegislation>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dcat:catalog>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:contactPoint>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:creator>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:description>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart>, <http://data.health-ri.nl/core/p2/CatalogShape#foaf:homepage>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:language>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:license>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:modified>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dcat:record>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:issued>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:rights>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:service>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:themeTaxonomy>,
+    <http://data.health-ri.nl/core/p2/CatalogShape#dct:title> .
 
-<http://data.health-ri.nl/core/p2/KindShape#vcard:hasURL> sh:path vcard:hasURL;
-  sh:name "contact page"@en;
-  sh:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact."@en;
+<http://data.health-ri.nl/core/p2/CatalogShape#dcatap:applicableLegislation> sh:path
+    dcatap:applicableLegislation;
+  sh:name "Applicable Legislation"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
-  sh:name "has email"@en;
-  sh:description "A email address via which contact can be made."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:catalog> sh:path dcat:catalog;
+  sh:name "catalog"@en;
+  sh:class dcat:Catalog .
 
-<http://data.health-ri.nl/core/p2/KindShape#vcard:fn> sh:path vcard:fn;
-  sh:name "formatted name"@en;
-  sh:description "The full name of the contact point."@en;
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:contactPoint> sh:path dcat:contactPoint;
+  sh:name "Contact point"@en;
   sh:minCount 1;
   sh:maxCount 1;
+  sh:node hri:KindShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dct:creator;
+  sh:name "creator"@en;
+  sh:node hri:AgentShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset> sh:path dcat:dataset;
+  sh:name "dataset"@en .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dct:description;
+  sh:name "description"@en;
+  sh:minCount 1;
   sh:nodeKind sh:Literal;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextAreaEditor .
 
-<https://data.sparna.fr/shapes-example#> a owl:Ontology;
-  rdfs:label "Dataset Series"@en, "DataService"@en, "Distribution"@en, "Catalog"@en;
-  rdfs:comment "Health-RI v2 Dataset Series"@en, "Health-RI v2 DataService."@en, "Health-RI v2 Distribution."@en,
-    "Health-RI v2 Catalog."@en;
-  dct:description "SHACL mandatory definitions for the Health-RI v2 model for Dataset Series."@en,
-    "SHACL definitions for the Health-RI v2 model for DataService."@en, "SHACL definitions for the Health-RI v2 model for Distribution."@en,
-    "SHACL definitions for the Health-RI v2 model for Catalog."@en;
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dct:spatial;
+  sh:name "geographical coverage"@en;
+  sh:description "The EU Vocabularies Name Authority Lists must be used for continents, countries and places that are in those lists; if a particular location is not in one of the mentioned Named Authority Lists, Geonames URIs must be used. For districts or neighbourhoods in NL, the Dutch vocab can be used."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dct:hasPart;
+  sh:name "has part"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#foaf:homepage> sh:path foaf:homepage;
+  sh:name "home page"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dct:language;
+  sh:name "language"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dct:license;
+  sh:name "licence"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dct:modified;
+  sh:name "modification date"@en;
+  sh:maxCount 1;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dct:publisher;
+  sh:name "publisher"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:node hri:AgentShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:record> sh:path dcat:record;
+  sh:name "record"@en;
+  sh:class dcat:CatalogRecord .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dct:issued;
+  sh:name "release date"@en;
+  sh:maxCount 1;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dct:rights;
+  sh:name "rights"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:service> sh:path dcat:service;
+  sh:name "service"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dct:temporal;
+  sh:name "temporal coverage"@en;
+  sh:node hri:PeriodOfTimeShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dcat:themeTaxonomy> sh:path dcat:themeTaxonomy;
+  sh:name "themes"@en;
+  sh:description "This property refers to a knowledge organisation system used to classify the Catalogue's Datasets. It must have at least the value NAL:data-theme as this is the mandatory controlled vocabulary for dcat:theme."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dct:title;
+  sh:name "title"@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+hri:ResourceShape a owl:Ontology, sh:NodeShape;
+  rdfs:label "Resource"@en;
+  rdfs:comment "Health-RI v2 Resource placeholder."@en;
+  dct:description "SHACL stub for the Health-RI v2 model for Resource."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:09.770Z"^^xsd:dateTime, "2025-04-23T13:25:32.440Z"^^xsd:dateTime,
-    "2025-04-23T13:25:14.930Z"^^xsd:dateTime, "2025-04-23T13:25:16.780Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:07.820Z"^^xsd:dateTime;
+  sh:targetClass dcat:Resource .
+
+hri:aux-PeriodOfTimeShape a owl:Ontology;
+  rdfs:label "Period of Time"@en;
+  rdfs:comment "Health-RI v2 Period of Time"@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-04-24T09:10:17.860Z"^^xsd:dateTime .
+
+hri:PeriodOfTimeShape a sh:NodeShape;
+  rdfs:label "Period of Time"@en;
+  sh:targetClass dct:PeriodOfTime;
+  sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
+
+<http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
+  sh:name "end date"@en;
+  sh:description "The end of the period."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> sh:path dcat:startDate;
+  sh:name "start date"@en;
+  sh:description "The start of the period."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
 
 hri:DatasetSeriesShape a sh:NodeShape;
   rdfs:label "DatasetSeries"@en;
@@ -178,93 +316,768 @@ hri:DatasetSeriesShape a sh:NodeShape;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-hri:aux-RelationshipShape a owl:Ontology;
-  rdfs:label "Relationship"@en;
-  rdfs:comment "Health-RI v2 Relationship"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Relationship."@en;
+hri:AgentShapeAgentShape a owl:Ontology;
+  rdfs:label "Agent class"@en;
+  rdfs:comment "Excel template for Agent class"@en;
+  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:25.790Z"^^xsd:dateTime .
+  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
 
-hri:RelationshipShape a sh:NodeShape;
-  rdfs:label "Relation"@en;
-  sh:targetClass dcat:Relationship;
-  sh:property <http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole>, <http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> .
+hri:AgentShape a sh:NodeShape;
+  rdfs:label "Agent"@en;
+  sh:targetClass foaf:Agent;
+  sh:property <http://data.health-ri.nl/core/p2/AgentShape#dct:spatial>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox>,
+    <http://data.health-ri.nl/core/p2/AgentShape#dct:identifier>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:name>,
+    <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
+    <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
 
-<http://data.health-ri.nl/core/p2/RelationshipShape#dcat:hadRole> sh:path dcat:hadRole;
-  sh:name "had role"@en;
-  sh:description "The nature of the relationship, as indicated via a value from the controlled vocabulary."@en;
-  sh:minCount 1;
+<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
+  sh:name "country"@en;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/RelationshipShape#dct:relation> sh:path dct:relation;
-  sh:name "relation"@en;
-  sh:description "A resource with a relationship to the cataloged resource."@en;
+<http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
+  sh:name "email"@en;
+  sh:description "An email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme. For example: mailto:info@example.com"@en;
   sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  sh:pattern "^mailto:.+@.+\\..+$";
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
+  sh:name "identifier"@en;
+  sh:description "A unique identifier of the agent."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextAreaEditor .
+
+<http://data.health-ri.nl/core/p2/AgentShape#foaf:name> sh:path foaf:name;
+  sh:name "name"@en;
+  sh:description "A name of the agent."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextAreaEditor .
+
+<http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote> sh:path healthdcatap:publishernote;
+  sh:name "publisher note"@en;
+  sh:description "A description of the publisher activities"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextAreaEditor .
+
+<http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype> sh:path healthdcatap:publishertype;
+  sh:name "publisher type"@en;
+  sh:description "A type of organisation that makes the Dataset available"@en;
+  sh:maxCount 1;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-hri:aux-IdentifierShape a owl:Ontology;
-  rdfs:label "Identifier"@en;
-  rdfs:comment "Health-RI v2 Identifier"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Identifier."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:22.090Z"^^xsd:dateTime .
+<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
+  sh:name "type"@en;
+  sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
 
-hri:IdentifierShape a sh:NodeShape;
-  rdfs:label "Identifier"@en;
-  sh:targetClass adms:Identifier;
-  sh:property <http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation>, <http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> .
-
-<http://data.health-ri.nl/core/p2/IdentifierShape#skos:notation> sh:path skos:notation;
-  sh:name "notation"@en;
-  sh:description "A string that is an identifier in the context of the identifier scheme referenced by its datatype."@en;
+<http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> sh:path foaf:homepage;
+  sh:name "URL"@en;
+  sh:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact."@en;
   sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+hri:KindShapeKindShape a owl:Ontology;
+  rdfs:label "Kind"@en;
+  rdfs:comment "Health-RI v2 Kind."@en;
+  dct:description "SHACL mandatory definitions for the Health-RI v2 model for vcard:Kind."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-05-02T06:45:41.960Z"^^xsd:dateTime .
+
+hri:KindShape a sh:NodeShape;
+  rdfs:label "Kind"@en;
+  sh:targetClass vcard:Kind;
+  sh:property <http://data.health-ri.nl/core/p2/KindShape#vcard:hasURL>, <http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail>,
+    <http://data.health-ri.nl/core/p2/KindShape#vcard:fn> .
+
+<http://data.health-ri.nl/core/p2/KindShape#vcard:hasURL> sh:path vcard:hasURL;
+  sh:name "contact page"@en;
+  sh:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/KindShape#vcard:hasEmail> sh:path vcard:hasEmail;
+  sh:name "has email"@en;
+  sh:description "A email address via which contact can be made. Make sure you use the correct format, starting with 'mailto:'. For example: mailto:info@example.com"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  sh:pattern "^mailto:.+@.+\\..+$";
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/KindShape#vcard:fn> sh:path vcard:fn;
+  sh:name "formatted name"@en;
+  sh:description "The full name of the contact point."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextAreaEditor .
+
+hri:DatasetShape a owl:Ontology, sh:NodeShape;
+  rdfs:label "Excel template for Dataset class"@en, "Dataset"@en;
+  rdfs:comment "Excel template for Dataset class"@en;
+  dct:description "This is an excel template for Dataset class in Health RI Core plateau 2."@en;
+  owl:versionInfo "0.1";
+  dct:modified "2025-02-10T00:00:00.000Z"^^xsd:dateTime;
+  sh:targetClass dcat:Dataset;
+  sh:property <http://data.health-ri.nl/core/p2/DatasetShape#access-rights>, <http://data.health-ri.nl/core/p2/DatasetShape#analytics>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation>, <http://data.health-ri.nl/core/p2/DatasetShape#code-values>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#coding-system>, <http://data.health-ri.nl/core/p2/DatasetShape#conforms-to>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#contact-point>, <http://data.health-ri.nl/core/p2/DatasetShape#creator>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#description>, <http://data.health-ri.nl/core/p2/DatasetShape#distribution>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#documentation>, <http://data.health-ri.nl/core/p2/DatasetShape#frequency>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage>, <http://data.health-ri.nl/core/p2/DatasetShape#has-version>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#health-theme>, <http://data.health-ri.nl/core/p2/DatasetShape#identifier>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#in-series>, <http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#keyword>, <http://data.health-ri.nl/core/p2/DatasetShape#language>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#legal-basis>, <http://data.health-ri.nl/core/p2/DatasetShape#maximum-typical-age>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#minimum-typical-age>, <http://data.health-ri.nl/core/p2/DatasetShape#modification-date>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#number-of-records>, <http://data.health-ri.nl/core/p2/DatasetShape#number-of-unique-infividuals>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#other-identifier>, <http://data.health-ri.nl/core/p2/DatasetShape#personal-data>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#population-coverage>, <http://data.health-ri.nl/core/p2/DatasetShape#publisher>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#purpose>, <http://data.health-ri.nl/core/p2/DatasetShape#qualified-attribution>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#qualified-relation>, <http://data.health-ri.nl/core/p2/DatasetShape#quality-annotation>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#release-date>, <http://data.health-ri.nl/core/p2/DatasetShape#retention-period>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#sample>, <http://data.health-ri.nl/core/p2/DatasetShape#source>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#status>, <http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#temporal-resolution>, <http://data.health-ri.nl/core/p2/DatasetShape#theme>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#title>, <http://data.health-ri.nl/core/p2/DatasetShape#type>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#version>, <http://data.health-ri.nl/core/p2/DatasetShape#version-notes>,
+    <http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by> .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#access-rights> sh:path dct:accessRights;
+  sh:name "access rights"@en;
+  sh:description "Information that indicates whether the Dataset is publicly accessible, has access restrictions or is not public. This property must be filled with a value from a controlled vocabulary."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  sh:in _:genid-da6932df208249999cca8f74f47df74862-BF6149BFECB8E84A2A1B741A5BC0B788;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:EnumSelectEditor .
+
+_:genid-da6932df208249999cca8f74f47df74862-BF6149BFECB8E84A2A1B741A5BC0B788 rdf:first
+    eu:PUBLIC;
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74862-9E62FD79D9F37683EED6986B00D42809 .
+
+_:genid-da6932df208249999cca8f74f47df74862-9E62FD79D9F37683EED6986B00D42809 rdf:first
+    eu:RESTRICTED;
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74862-54095F1B2782AEC4774D363AA503AFE3 .
+
+_:genid-da6932df208249999cca8f74f47df74862-54095F1B2782AEC4774D363AA503AFE3 rdf:first
+    eu:NON_PUBLIC;
+  rdf:rest rdf:nil .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#analytics> sh:path healthdcatap:analytics;
+  sh:name "analytics"@en;
+  sh:description "An analytics distribution of the dataset"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation> sh:path dcatap:applicableLegislation;
+  sh:name "applicable legislation"@en;
+  sh:description "The legislation that mandates the creation or management of the Dataset. The default value is the ELI of the EHDS."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:IRI;
+  sh:defaultValue <http://data.europa.eu/eli/reg/2025/327/oj>;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#code-values> sh:path healthdcatap:hasCodeValues;
+  sh:name "code values"@en;
+  sh:description "Health classifications and their codes associated with the dataset"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#coding-system> sh:path healthdcatap:hasCodingSystem;
+  sh:name "coding system"@en;
+  sh:description "Coding systems in use (ex: ICD-10-CM, DGRs, SNOMED=CT, ...)"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#conforms-to> sh:path dct:conformsTo;
+  sh:name "conforms to"@en;
+  sh:description "An implementing rule or other specification"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#contact-point> sh:path dcat:contactPoint;
+  sh:name "contact point"@en;
+  sh:description "Contact information that can be used for sending comments about the Dataset."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:node hri:KindShape;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#creator> sh:path dct:creator;
+  sh:name "creator"@en;
+  sh:description "An entity responsible for producing the dataset."@en;
+  sh:minCount 1;
+  sh:node hri:AgentShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#description> sh:path dct:description;
+  sh:name "description"@en;
+  sh:description "A free-text account of the Dataset."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#distribution> sh:path dcat:distribution;
+  sh:name "distribution"@en;
+  sh:description "An available Distribution for the Dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#documentation> sh:path foaf:page;
+  sh:name "documentation"@en;
+  sh:description "A page or document about this Dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#frequency> sh:path dct:accrualPeriodicity;
+  sh:name "frequency"@en;
+  sh:description "The frequency at which the Dataset is updated. This property must be filled with a value from a controlled vocabulary."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage> sh:path dct:spatial;
+  sh:name "geographical coverage"@en;
+  sh:description "A geographic region that is covered by the Dataset. This property must be filled with a value from a controlled vocabulary."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#has-version> sh:path dcat:hasVersion;
+  sh:name "has version"@en;
+  sh:description "A related Dataset that is a version, edition, or adaptation of the described Dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#health-theme> sh:path healthdcatap:healthTheme;
+  sh:name "health theme"@en;
+  sh:description "A category of the Dataset or tag describing the Dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#identifier> sh:path dct:identifier;
+  sh:name "identifier"@en;
+  sh:description "The main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#in-series> sh:path dcat:inSeries;
+  sh:name "in series"@en;
+  sh:description "A dataset series of which the dataset is part."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by> sh:path dct:isReferencedBy;
+  sh:name "is referenced by"@en;
+  sh:description "A related resource, such as a publication, that references, cites, or otherwise points to the dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#keyword> sh:path dcat:keyword;
+  sh:name "keyword"@en;
+  sh:description "A keyword or tag describing the Dataset."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#language> sh:path dct:language;
+  sh:name "language"@en;
+  sh:description "A language of the Dataset.This property must be filled with a value from a controlled vocabulary."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dpv:hasLegalBasis;
+  sh:name "legal basis"@en;
+  sh:description "The legal basis used to justify processing of personal data. The legal basis can be provided as a value from the dpv taxonomy and should be provided via IRI, for example https://w3id.org/dpv#Consent"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#maximum-typical-age> sh:path healthdcatap:maxTypicalAge;
+  sh:name "maximum typical age"@en;
+  sh:description "Maximum typical age of the population within the dataset"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:nonNegativeInteger;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#minimum-typical-age> sh:path healthdcatap:minTypicalAge;
+  sh:name "minimum typical age"@en;
+  sh:description "Minimum typical age of the population within the dataset"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:nonNegativeInteger;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#modification-date> sh:path dct:modified;
+  sh:name "modification date"@en;
+  sh:description "The most recent date on which the Dataset was changed or modified."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#number-of-records> sh:path healthdcatap:numberOfRecords;
+  sh:name "number of records"@en;
+  sh:description "Size of the dataset in terms of the number of records"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:nonNegativeInteger;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#number-of-unique-infividuals> sh:path
+    healthdcatap:numberOfUniqueIndividuals;
+  sh:name "number of unique infividuals"@en;
+  sh:description "Number of records for unique individuals."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:nonNegativeInteger;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#other-identifier> sh:path adms:identifier;
+  sh:name "other identifier"@en;
+  sh:description "A secondary identifier of the Dataset, such as MAST/ADS17, DataCite18, DOI19, EZID20 or W3ID21"@en;
+  sh:node hri:IdentifierShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dpv:hasPersonalData;
+  sh:name "personal data"@en;
+  sh:description "Key elements that represent an individual in the dataset. Values can be picked from the dpv taxonomy, for example https://w3id.org/dpv/dpv-pd#Gender"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:LabelViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#population-coverage> sh:path healthdcatap:populationCoverage;
+  sh:name "population coverage"@en;
+  sh:description "A definition of the population within the dataset"@en;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#publisher> sh:path dct:publisher;
+  sh:name "publisher"@en;
+  sh:description "An entity (organisation) responsible for making the Dataset available."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:node hri:AgentShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dpv:hasPurpose;
+  sh:name "purpose"@en;
+  sh:description "Indicates association with Purpose. One (or many) category or sub-category of the purposes can be chosen from the taxonomy provided by dpv and should be provided via IRI, for example https://w3id.org/dpv#ScientificResearch"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:LabelViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#qualified-attribution> sh:path prov:qualifiedAttribution;
+  sh:name "qualified attribution"@en;
+  sh:description "An Agent having some form of responsibility for the resource"@en;
+  sh:node hri:AttributionShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#qualified-relation> sh:path dcat:qualifiedRelation;
+  sh:name "qualified relation"@en;
+  sh:description "A description of a relationship with another resource"@en;
+  sh:node hri:RelationshipShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#quality-annotation> sh:path dqv:hasQualityAnnotation;
+  sh:name "quality annotation"@en;
+  sh:description "A statement related to quality of the Dataset, including rating, quality certificate, feedback that can be associated to the dataset"@en;
+  sh:node hri:QualityCertificateShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#release-date> sh:path dct:issued;
+  sh:name "release date"@en;
+  sh:description "The date of formal issuance (e.g., publication) of the Dataset."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#retention-period> sh:path healthdcatap:retentionPeriod;
+  sh:name "retention period"@en;
+  sh:description "A temporal period which the dataset is available for secondary use"@en;
+  sh:maxCount 1;
+  sh:node hri:PeriodOfTimeShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#sample> sh:path adms:sample;
+  sh:name "sample"@en;
+  sh:description "A sample distribution of the dataset"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#source> sh:path dct:source;
+  sh:name "source"@en;
+  sh:description "A related dataset from which the described dataset is derived"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#status> sh:path adms:status;
+  sh:name "status"@en;
+  sh:description "The status of a dataset. This property can be filled with a value from a controlled vocabulary."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage> sh:path dct:temporal;
+  sh:name "temporal coverage"@en;
+  sh:description "A temporal period that the Dataset covers."@en;
+  sh:node hri:PeriodOfTimeShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#temporal-resolution> sh:path dcat:temporalResolution;
+  sh:name "temporal resolution"@en;
+  sh:description "The minimum time period resolvable in the dataset."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:duration;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#theme> sh:path dcat:theme;
+  sh:name "theme"@en;
+  sh:description "A category of the Dataset. This property must be filled with a value from a controlled vocabulary. The default value of this property is http://publications.europa.eu/resource/authority/data-theme/HEAL from the controlled vocabulary."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:IRI;
+  sh:defaultValue <http://publications.europa.eu/resource/authority/data-theme/HEAL>;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#title> sh:path dct:title;
+  sh:name "title"@en;
+  sh:description "A name given to the Dataset."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:string;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#type> sh:path dct:type;
+  sh:name "type"@en;
+  sh:description "A type of the Dataset.This property must be filled with a value from a controlled vocabulary."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DatasetShape#version> sh:path dcat:version;
+  sh:name "version"@en;
+  sh:description "The version indicator (name or identifier) of a resource."@en;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:string;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-<http://data.health-ri.nl/core/p2/IdentifierShape#adms:schemaAgency> sh:path adms:schemaAgency;
-  sh:name "schema agency"@en;
-  sh:description "The name of the agency that issued the identifier."@en;
-  sh:maxCount 1;
+<http://data.health-ri.nl/core/p2/DatasetShape#version-notes> sh:path adms:versionNotes;
+  sh:name "version notes"@en;
+  sh:description "A description of the differences between this version and a previous version of the Dataset"@en;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:string;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
 
-hri:aux-QualityCertificateShape a owl:Ontology;
-  rdfs:label "Quality Certificate"@en;
-  rdfs:comment "Health-RI v2 Quality Certificate"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Quality Certificate."@en;
+<http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by> sh:path prov:wasGeneratedBy;
+  sh:name "was generated by"@en;
+  sh:description "An activity that generated, or provides the business context for, the creation of the dataset."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+hri:DistributionShape a sh:NodeShape;
+  rdfs:label "Distribution"@en;
+  sh:targetClass dcat:Distribution;
+  sh:property <http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessService>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessURL>, <http://data.health-ri.nl/core/p2/DistributionShape#dcatap:applicableLegislation>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:byteSize>, <http://data.health-ri.nl/core/p2/DistributionShape#spdx:checksum>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:compressFormat>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:description>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#foaf:page>, <http://data.health-ri.nl/core/p2/DistributionShape#dcat:downloadURL>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dct:format>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:language>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dct:license>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:mediaType>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:modified>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:packageFormat>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:issued>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#healthdcatap:retentionperiod>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dct:rights>, <http://data.health-ri.nl/core/p2/DistributionShape#adms:status>,
+    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:title> .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessService> sh:path dcat:accessService;
+  sh:name "access service"@en;
+  sh:maxCount 1;
+  sh:class dcat:DataService .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessURL> sh:path dcat:accessURL;
+  sh:name "access url"@en;
+  sh:description "The resource at the access URL may contain information about how to get the Dataset."@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcatap:applicableLegislation>
+  sh:path dcatap:applicableLegislation;
+  sh:name "Applicable Legislation"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:byteSize> sh:path dcat:byteSize;
+  sh:name "byte size"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:Literal;
+  sh:datatype xsd:integer;
+  sh:minExclusive 0;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#spdx:checksum> sh:path spdx:checksum;
+  sh:name "checksum"@en;
+  sh:description "The checksum is related to the downloadURL."@en;
+  sh:maxCount 1;
+  sh:node hri:ChecksumShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:compressFormat> sh:path dcat:compressFormat;
+  sh:name "compression format"@en;
+  sh:description "It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dct:description;
+  sh:name "description"@en;
+  sh:description "This property can be repeated for parallel language versions of the description."@en;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#foaf:page> sh:path foaf:page;
+  sh:name "documentation"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:downloadURL> sh:path dcat:downloadURL;
+  sh:name "download URL"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dct:format;
+  sh:name "format"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dct:language;
+  sh:name "language"@en;
+  sh:description "This property can be repeated if the metadata is provided in multiple languages."@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dct:license;
+  sh:name "license"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dct:conformsTo;
+  sh:name "linked schemas"@en;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:mediaType> sh:path dcat:mediaType;
+  sh:name "media type"@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dct:modified;
+  sh:name "modification date"@en;
+  sh:maxCount 1;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:packageFormat> sh:path dcat:packageFormat;
+  sh:name "packaging format"@en;
+  sh:description "It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dct:issued;
+  sh:name "release date"@en;
+  sh:description "The date the dataset distribution was issued."@en;
+  sh:maxCount 1;
+  sh:datatype xsd:dateTime;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:DateTimePickerEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#healthdcatap:retentionperiod>
+  sh:path healthdcatap:retentionperiod;
+  sh:name "retention period"@en;
+  sh:node hri:PeriodOfTimeShape;
+  dash:viewer dash:DetailsViewer;
+  dash:editor dash:BlankNodeEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dct:rights;
+  sh:name "rights"@en;
+  sh:description "A statement that concerns all rights not addressed in fields License or Rights, such as copyright statements. Everything that is not covered with licece"@en;
+  sh:minCount 1;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:URIEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#adms:status> sh:path adms:status;
+  sh:name "status"@en;
+  sh:description "The status of the distribution in the context of maturity lifecycle."@en;
+  sh:maxCount 1;
+  sh:nodeKind sh:IRI;
+  sh:in _:genid-da6932df208249999cca8f74f47df74864-B8C0D19C0D0A0AADD3F5BBB535A1757B;
+  dash:viewer dash:URIViewer;
+  dash:editor dash:EnumSelectEditor .
+
+_:genid-da6932df208249999cca8f74f47df74864-B8C0D19C0D0A0AADD3F5BBB535A1757B rdf:first
+    status:COMPLETED;
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74864-BC386D931CCC43EB5DCD940CDE56E1B4 .
+
+_:genid-da6932df208249999cca8f74f47df74864-BC386D931CCC43EB5DCD940CDE56E1B4 rdf:first
+    status:DEVELOP;
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74864-05FAACE1BBFD2C2DEC85572B168435DA .
+
+_:genid-da6932df208249999cca8f74f47df74864-05FAACE1BBFD2C2DEC85572B168435DA rdf:first
+    status:WITHDRAWN;
+  rdf:rest _:genid-da6932df208249999cca8f74f47df74864-AD0B8CAF3108E4231B2E6E045AC9894E .
+
+_:genid-da6932df208249999cca8f74f47df74864-AD0B8CAF3108E4231B2E6E045AC9894E rdf:first
+    status:DEPRECATED;
+  rdf:rest rdf:nil .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution> sh:path
+    dcat:temporalResolution;
+  sh:name "temporal resolution"@en;
+  sh:maxCount 1;
+  sh:datatype xsd:duration;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dct:title;
+  sh:name "title"@en;
+  sh:description "This property can be repeated for parallel language versions of the description."@en;
+  sh:minCount 1;
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextFieldEditor .
+
+hri:aux-ChecksumShape a owl:Ontology;
+  rdfs:label "Checksum"@en;
+  rdfs:comment "Health-RI v2 Checksum."@en;
+  dct:description "SHACL definitions for the Health-RI v2 model for Checksum."@en;
   owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:27.610Z"^^xsd:dateTime .
+  dct:modified "2025-04-23T13:25:19.220Z"^^xsd:dateTime .
 
-hri:QualityCertificateShape a sh:NodeShape;
-  rdfs:label "Quality Certificate"@en;
-  sh:targetClass dqv:QualityCertificate;
-  sh:property <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget>,
-    <http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> .
+hri:ChecksumShape a sh:NodeShape;
+  rdfs:label "Checksum"@en;
+  sh:targetClass spdx:Checksum;
+  sh:property <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:algorithm>, <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:checksumValue> .
 
-<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasTarget> sh:path oa:hasTarget;
-  sh:name "target"@en;
-  sh:description "The identifier of the described resource targetet by the quality certificate."@en;
+<http://data.health-ri.nl/core/p2/ChecksumShape#spdx:algorithm> sh:path spdx:algorithm;
+  sh:name "algorithm"@en;
+  sh:description "The algorithm used to produce the subject Checksum"@en;
+  sh:minCount 1;
   sh:maxCount 1;
   sh:nodeKind sh:IRI;
   dash:viewer dash:URIViewer;
   dash:editor dash:URIEditor .
 
-<http://data.health-ri.nl/core/p2/QualityCertificateShape#oa:hasBody> sh:path oa:hasBody;
-  sh:name "body"@en;
-  sh:description "The (web)location of the quality certificate."@en;
+<http://data.health-ri.nl/core/p2/ChecksumShape#spdx:checksumValue> sh:path spdx:checksumValue;
+  sh:name "checksum value"@en;
+  sh:description "A lower case hexadecimal encoded digest value produced using a specific algorithm"@en;
+  sh:minCount 1;
   sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
+  sh:nodeKind sh:Literal;
+  dash:viewer dash:LiteralViewer;
+  dash:editor dash:TextAreaEditor .
 
 hri:DataServiceShape a sh:NodeShape;
   rdfs:label "DataService"@en;
@@ -448,948 +1261,3 @@ hri:DataServiceShape a sh:NodeShape;
   sh:nodeKind sh:Literal;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:TextFieldEditor .
-
-hri:AgentShapeAgentShape a owl:Ontology;
-  rdfs:label "Agent class"@en;
-  rdfs:comment "Excel template for Agent class"@en;
-  dct:description "This is an excel template for Agent class in Health RI Core plateau 2."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2024-02-10T00:00:00.000Z"^^xsd:dateTime .
-
-hri:AgentShape a sh:NodeShape;
-  rdfs:label "Agent"@en;
-  sh:targetClass foaf:Agent;
-  sh:property <http://data.health-ri.nl/core/p2/AgentShape#dct:spatial>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox>,
-    <http://data.health-ri.nl/core/p2/AgentShape#dct:identifier>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:name>,
-    <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote>, <http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype>,
-    <http://data.health-ri.nl/core/p2/AgentShape#dct:type>, <http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> .
-
-<http://data.health-ri.nl/core/p2/AgentShape#dct:spatial> sh:path dct:spatial;
-  sh:name "country"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#foaf:mbox> sh:path foaf:mbox;
-  sh:name "email"@en;
-  sh:description "A email address via which contact can be made. This property SHOULD be used to provide the email address of the Agent, specified using fully qualified mailto: URI scheme [RFC6068]. The email SHOULD be used to establish a communication channel to the agent."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  sh:pattern "^mailto:.+@.+\\..+$";
-  sh:defaultValue <mailto:>;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#dct:identifier> sh:path dct:identifier;
-  sh:name "identifier"@en;
-  sh:description "A unique identifier of the agent."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextAreaEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#foaf:name> sh:path foaf:name;
-  sh:name "name"@en;
-  sh:description "A name of the agent."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextAreaEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishernote> sh:path healthdcatap:publishernote;
-  sh:name "publisher note"@en;
-  sh:description "A description of the publisher activities"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextAreaEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#healthdcatap:publishertype> sh:path healthdcatap:publishertype;
-  sh:name "publisher type"@en;
-  sh:description "A type of organisation that makes the Dataset available"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#dct:type> sh:path dct:type;
-  sh:name "type"@en;
-  sh:description "A type of the agent that makes the Catalogue or Dataset available"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/AgentShape#foaf:homepage> sh:path foaf:homepage;
-  sh:name "URL"@en;
-  sh:description "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-hri:aux-ChecksumShape a owl:Ontology;
-  rdfs:label "Checksum"@en;
-  rdfs:comment "Health-RI v2 Checksum."@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Checksum."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:19.220Z"^^xsd:dateTime .
-
-hri:ChecksumShape a sh:NodeShape;
-  rdfs:label "Checksum"@en;
-  sh:targetClass spdx:Checksum;
-  sh:property <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:algorithm>, <http://data.health-ri.nl/core/p2/ChecksumShape#spdx:checksumValue> .
-
-<http://data.health-ri.nl/core/p2/ChecksumShape#spdx:algorithm> sh:path spdx:algorithm;
-  sh:name "algorithm"@en;
-  sh:description "The algorithm used to produce the subject Checksum"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/ChecksumShape#spdx:checksumValue> sh:path spdx:checksumValue;
-  sh:name "checksum value"@en;
-  sh:description "A lower case hexadecimal encoded digest value produced using a specific algorithm"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextAreaEditor .
-
-hri:aux-PeriodOfTimeShape a owl:Ontology;
-  rdfs:label "Period of Time"@en;
-  rdfs:comment "Health-RI v2 Period of Time"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Period of Time."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-24T08:40:25.850Z"^^xsd:dateTime .
-
-hri:PeriodOfTimeShape a sh:NodeShape;
-  rdfs:label "Period of Time"@en;
-  sh:targetClass dct:PeriodOfTime;
-  sh:property <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate>, <http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> .
-
-<http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:endDate> sh:path dcat:endDate;
-  sh:name "end date"@en;
-  sh:description "The end of the period."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/PeriodOfTimeShape#dcat:startDate> sh:path dcat:startDate;
-  sh:name "start date"@en;
-  sh:description "The start of the period."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-hri:ResourceShape a owl:Ontology, sh:NodeShape;
-  rdfs:label "Resource"@en;
-  rdfs:comment "Health-RI v2 Resource placeholder."@en;
-  dct:description "SHACL stub for the Health-RI v2 model for Resource."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:07.820Z"^^xsd:dateTime;
-  sh:targetClass dcat:Resource .
-
-hri:DistributionShape a sh:NodeShape;
-  rdfs:label "Distribution"@en;
-  sh:targetClass dcat:Distribution;
-  sh:property <http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessService>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessURL>, <http://data.health-ri.nl/core/p2/DistributionShape#dcatap:applicableLegislation>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:byteSize>, <http://data.health-ri.nl/core/p2/DistributionShape#spdx:checksum>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:compressFormat>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:description>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#foaf:page>, <http://data.health-ri.nl/core/p2/DistributionShape#dcat:downloadURL>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dct:format>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:language>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dct:license>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:mediaType>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:modified>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:packageFormat>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:issued>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#healthdcatap:retentionperiod>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dct:rights>, <http://data.health-ri.nl/core/p2/DistributionShape#adms:status>,
-    <http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution>, <http://data.health-ri.nl/core/p2/DistributionShape#dct:title> .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessService> sh:path dcat:accessService;
-  sh:name "access service"@en;
-  sh:maxCount 1;
-  sh:class dcat:DataService .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:accessURL> sh:path dcat:accessURL;
-  sh:name "access url"@en;
-  sh:description "The resource at the access URL may contain information about how to get the Dataset."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcatap:applicableLegislation>
-  sh:path dcatap:applicableLegislation;
-  sh:name "Applicable Legislation"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:byteSize> sh:path dcat:byteSize;
-  sh:name "byte size"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:integer;
-  sh:minExclusive "0";
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#spdx:checksum> sh:path spdx:checksum;
-  sh:name "checksum"@en;
-  sh:description "The checksum is related to the downloadURL."@en;
-  sh:maxCount 1;
-  sh:node hri:ChecksumShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:compressFormat> sh:path dcat:compressFormat;
-  sh:name "compression format"@en;
-  sh:description "It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:description> sh:path dct:description;
-  sh:name "description"@en;
-  sh:description "This property can be repeated for parallel language versions of the description."@en;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#foaf:page> sh:path foaf:page;
-  sh:name "documentation"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:downloadURL> sh:path dcat:downloadURL;
-  sh:name "download URL"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:format> sh:path dct:format;
-  sh:name "format"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:language> sh:path dct:language;
-  sh:name "language"@en;
-  sh:description "This property can be repeated if the metadata is provided in multiple languages."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:license> sh:path dct:license;
-  sh:name "license"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:conformsTo> sh:path dct:conformsTo;
-  sh:name "linked schemas"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:mediaType> sh:path dcat:mediaType;
-  sh:name "media type"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:modified> sh:path dct:modified;
-  sh:name "modification date"@en;
-  sh:maxCount 1;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:packageFormat> sh:path dcat:packageFormat;
-  sh:name "packaging format"@en;
-  sh:description "It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:issued> sh:path dct:issued;
-  sh:name "release date"@en;
-  sh:description "The date the dataset distribution was issued."@en;
-  sh:maxCount 1;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#healthdcatap:retentionperiod>
-  sh:path healthdcatap:retentionperiod;
-  sh:name "retention period"@en;
-  sh:node hri:PeriodOfTimeShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:rights> sh:path dct:rights;
-  sh:name "rights"@en;
-  sh:description "A statement that concerns all rights not addressed in fields License or Rights, such as copyright statements. Everything that is not covered with licece"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#adms:status> sh:path adms:status;
-  sh:name "status"@en;
-  sh:description "The status of the distribution in the context of maturity lifecycle."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  sh:in _:genid-d2c31ce987834c0fba07706c044768d478-B396BA40C83BE1233A13144FBEBE93C4;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:EnumSelectEditor .
-
-_:genid-d2c31ce987834c0fba07706c044768d478-B396BA40C83BE1233A13144FBEBE93C4 rdf:first
-    status:COMPLETED;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d478-442A834CC308C8C0D654E85281B9F6EB .
-
-_:genid-d2c31ce987834c0fba07706c044768d478-442A834CC308C8C0D654E85281B9F6EB rdf:first
-    status:DEVELOP;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d478-42082B56D9E213FC9A7E6F60C32EDE03 .
-
-_:genid-d2c31ce987834c0fba07706c044768d478-42082B56D9E213FC9A7E6F60C32EDE03 rdf:first
-    status:WITHDRAWN;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d478-92A8D1416B18A12FB6A5198CD2A204AE .
-
-_:genid-d2c31ce987834c0fba07706c044768d478-92A8D1416B18A12FB6A5198CD2A204AE rdf:first
-    status:DEPRECATED;
-  rdf:rest rdf:nil .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dcat:temporalResolution> sh:path
-    dcat:temporalResolution;
-  sh:name "temporal resolution"@en;
-  sh:maxCount 1;
-  sh:datatype xsd:duration;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DistributionShape#dct:title> sh:path dct:title;
-  sh:name "title"@en;
-  sh:description "This property can be repeated for parallel language versions of the description."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-hri:CatalogShape a sh:NodeShape;
-  rdfs:label "Catalog"@en;
-  sh:targetClass dcat:Catalog;
-  sh:property <http://data.health-ri.nl/core/p2/CatalogShape#dcatap:applicableLegislation>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dcat:catalog>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:contactPoint>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:creator>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:description>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart>, <http://data.health-ri.nl/core/p2/CatalogShape#foaf:homepage>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:language>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:license>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:modified>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dcat:record>, <http://data.health-ri.nl/core/p2/CatalogShape#dct:issued>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:rights>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:service>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal>, <http://data.health-ri.nl/core/p2/CatalogShape#dcat:themeTaxonomy>,
-    <http://data.health-ri.nl/core/p2/CatalogShape#dct:title> .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcatap:applicableLegislation> sh:path
-    dcatap:applicableLegislation;
-  sh:name "Applicable Legislation"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:catalog> sh:path dcat:catalog;
-  sh:name "catalog"@en;
-  sh:class dcat:Catalog .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:contactPoint> sh:path dcat:contactPoint;
-  sh:name "Contact point"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:node hri:KindShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:creator> sh:path dct:creator;
-  sh:name "creator"@en;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:dataset> sh:path dcat:dataset;
-  sh:name "dataset"@en .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:description> sh:path dct:description;
-  sh:name "description"@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextAreaEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:spatial> sh:path dct:spatial;
-  sh:name "geographical coverage"@en;
-  sh:description "The EU Vocabularies Name Authority Lists must be used for continents, countries and places that are in those lists; if a particular location is not in one of the mentioned Named Authority Lists, Geonames URIs must be used. For districts or neighbourhoods in NL, the Dutch vocab can be used."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:hasPart> sh:path dct:hasPart;
-  sh:name "has part"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#foaf:homepage> sh:path foaf:homepage;
-  sh:name "home page"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:language> sh:path dct:language;
-  sh:name "language"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:license> sh:path dct:license;
-  sh:name "licence"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:modified> sh:path dct:modified;
-  sh:name "modification date"@en;
-  sh:maxCount 1;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:publisher> sh:path dct:publisher;
-  sh:name "publisher"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:record> sh:path dcat:record;
-  sh:name "record"@en;
-  sh:class dcat:CatalogRecord .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:issued> sh:path dct:issued;
-  sh:name "release date"@en;
-  sh:maxCount 1;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:rights> sh:path dct:rights;
-  sh:name "rights"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:service> sh:path dcat:service;
-  sh:name "service"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:temporal> sh:path dct:temporal;
-  sh:name "temporal coverage"@en;
-  sh:node hri:PeriodOfTimeShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dcat:themeTaxonomy> sh:path dcat:themeTaxonomy;
-  sh:name "themes"@en;
-  sh:description "This property refers to a knowledge organisation system used to classify the Catalogue's Datasets. It must have at least the value NAL:data-theme as this is the mandatory controlled vocabulary for dcat:theme."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/CatalogShape#dct:title> sh:path dct:title;
-  sh:name "title"@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-hri:aux-AttributionShape a owl:Ontology;
-  rdfs:label "Attribution"@en;
-  rdfs:comment "Health-RI v2 Attribution"@en;
-  dct:description "SHACL definitions for the Health-RI v2 model for Attribution."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-04-23T13:25:20.480Z"^^xsd:dateTime .
-
-hri:AttributionShape a sh:NodeShape;
-  rdfs:label "Attribution"@en;
-  sh:targetClass prov:Attribution;
-  sh:property <http://data.health-ri.nl/core/p2/AttributionShape#prov:agent>, <http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> .
-
-<http://data.health-ri.nl/core/p2/AttributionShape#prov:agent> sh:path prov:agent;
-  sh:name "agent"@en;
-  sh:description "The agent that has a specific role with the described resource."@en;
-  sh:maxCount 1;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/AttributionShape#dcat:hadRole> sh:path dcat:hadRole;
-  sh:name "role"@en;
-  sh:description "The nature of the relationship between the agent and the described resource, as indicated by a value from the controlled vocabulary."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
-
-hri:DatasetShape a owl:Ontology, sh:NodeShape;
-  rdfs:label "Excel template for Dataset class"@en, "Dataset"@en;
-  rdfs:comment "Excel template for Dataset class"@en;
-  dct:description "This is an excel template for Dataset class in Health RI Core plateau 2."@en;
-  owl:versionInfo "0.1";
-  dct:modified "2025-02-10T00:00:00.000Z"^^xsd:dateTime;
-  sh:targetClass dcat:Dataset;
-  sh:property <http://data.health-ri.nl/core/p2/DatasetShape#access-rights>, <http://data.health-ri.nl/core/p2/DatasetShape#analytics>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation>, <http://data.health-ri.nl/core/p2/DatasetShape#code-values>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#coding-system>, <http://data.health-ri.nl/core/p2/DatasetShape#conforms-to>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#contact-point>, <http://data.health-ri.nl/core/p2/DatasetShape#creator>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#data-origin>, <http://data.health-ri.nl/core/p2/DatasetShape#description>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#distribution>, <http://data.health-ri.nl/core/p2/DatasetShape#documentation>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#frequency>, <http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#has-version>, <http://data.health-ri.nl/core/p2/DatasetShape#health-theme>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#identifier>, <http://data.health-ri.nl/core/p2/DatasetShape#in-series>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by>, <http://data.health-ri.nl/core/p2/DatasetShape#keyword>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#language>, <http://data.health-ri.nl/core/p2/DatasetShape#legal-basis>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#maximum-typical-age>, <http://data.health-ri.nl/core/p2/DatasetShape#minimum-typical-age>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#modification-date>, <http://data.health-ri.nl/core/p2/DatasetShape#number-of-records>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#number-of-unique-infividuals>, <http://data.health-ri.nl/core/p2/DatasetShape#other-identifier>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#personal-data>, <http://data.health-ri.nl/core/p2/DatasetShape#population-coverage>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#publisher>, <http://data.health-ri.nl/core/p2/DatasetShape#purpose>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#qualified-attribution>, <http://data.health-ri.nl/core/p2/DatasetShape#qualified-relation>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#quality-annotation>, <http://data.health-ri.nl/core/p2/DatasetShape#release-date>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#retention-period>, <http://data.health-ri.nl/core/p2/DatasetShape#sample>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#source>, <http://data.health-ri.nl/core/p2/DatasetShape#status>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage>, <http://data.health-ri.nl/core/p2/DatasetShape#temporal-resolution>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#theme>, <http://data.health-ri.nl/core/p2/DatasetShape#title>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#type>, <http://data.health-ri.nl/core/p2/DatasetShape#version>,
-    <http://data.health-ri.nl/core/p2/DatasetShape#version-notes>, <http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by> .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#access-rights> sh:path dct:accessRights;
-  sh:name "access rights"@en;
-  sh:description "Information that indicates whether the Dataset is publicly accessible, has access restrictions or is not public"@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  sh:in _:genid-d2c31ce987834c0fba07706c044768d484-A4F8C566E3D11C9A59DEBF73B60C3A6F;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:EnumSelectEditor .
-
-_:genid-d2c31ce987834c0fba07706c044768d484-A4F8C566E3D11C9A59DEBF73B60C3A6F rdf:first
-    eu:PUBLIC;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d484-EB7992645AB487168EF7E341B86543AF .
-
-_:genid-d2c31ce987834c0fba07706c044768d484-EB7992645AB487168EF7E341B86543AF rdf:first
-    eu:RESTRICTED;
-  rdf:rest _:genid-d2c31ce987834c0fba07706c044768d484-63129C2972DE0464775C6D3A0A1DDC58 .
-
-_:genid-d2c31ce987834c0fba07706c044768d484-63129C2972DE0464775C6D3A0A1DDC58 rdf:first
-    eu:NON_PUBLIC;
-  rdf:rest rdf:nil .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#analytics> sh:path healthdcatap:analytics;
-  sh:name "analytics"@en;
-  sh:description "An analytics distribution of the dataset"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#applicable-legislation> sh:path dcatap:applicableLegislation;
-  sh:name "applicable legislation"@en;
-  sh:description "The legislation that mandates the creation or management of the Dataset."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:IRI;
-  sh:defaultValue <http://data.europa.eu/eli/reg/2025/327/oj>;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#code-values> sh:path healthdcatap:hasCodeValues;
-  sh:name "code values"@en;
-  sh:description "Health classifications and their codes associated with the dataset"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#coding-system> sh:path healthdcatap:hasCodingSystem;
-  sh:name "coding system"@en;
-  sh:description "Coding systems in use (ex: ICD-10-CM, DGRs, SNOMED=CT, ...)"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#conforms-to> sh:path dct:conformsTo;
-  sh:name "conforms to"@en;
-  sh:description "An implementing rule or other specification"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#contact-point> sh:path dcat:contactPoint;
-  sh:name "contact point"@en;
-  sh:description "Contact information that can be used for sending comments about the Dataset."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:node hri:KindShape;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#creator> sh:path dct:creator;
-  sh:name "creator"@en;
-  sh:description "An entity responsible for producing the dataset."@en;
-  sh:minCount 1;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#data-origin> sh:path efo:EFO_0022043;
-  sh:name "data origin"@en;
-  sh:description "The origin of the data in the data set"@en;
-  sh:maxCount 1;
-  sh:datatype xsd:boolean;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:BooleanSelectEdito .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#description> sh:path dct:description;
-  sh:name "description"@en;
-  sh:description "A free-text account of the Dataset."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#distribution> sh:path dcat:distribution;
-  sh:name "distribution"@en;
-  sh:description "An available Distribution for the Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#documentation> sh:path foaf:page;
-  sh:name "documentation"@en;
-  sh:description "A page or document about this Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#frequency> sh:path dct:accrualPeriodicity;
-  sh:name "frequency"@en;
-  sh:description "The frequency at which the Dataset is updated"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#geographical-coverage> sh:path dct:spatial;
-  sh:name "geographical coverage"@en;
-  sh:description "A geographic region that is covered by the Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#has-version> sh:path dcat:hasVersion;
-  sh:name "has version"@en;
-  sh:description "A related Dataset that is a version, edition, or adaptation of the described Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#health-theme> sh:path healthdcatap:healthTheme;
-  sh:name "health theme"@en;
-  sh:description "A category of the Dataset or tag describing the Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#identifier> sh:path dct:identifier;
-  sh:name "identifier"@en;
-  sh:description "The main identifier for the Dataset, e.g. the URI or other unique identifier in the context of the Catalogue."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#in-series> sh:path dcat:inSeries;
-  sh:name "in series"@en;
-  sh:description "A dataset series of which the dataset is part."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#is-referenced-by> sh:path dct:isReferencedBy;
-  sh:name "is referenced by"@en;
-  sh:description "A related resource, such as a publication, that references, cites, or otherwise points to the dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#keyword> sh:path dcat:keyword;
-  sh:name "keyword"@en;
-  sh:description "A keyword or tag describing the Dataset."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#language> sh:path dct:language;
-  sh:name "language"@en;
-  sh:description "A language of the Dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#legal-basis> sh:path dpv:hasLegalBasis;
-  sh:name "legal basis"@en;
-  sh:description "The legal basis used to justify processing of personal data"@en;
-  sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#maximum-typical-age> sh:path healthdcatap:maxTypicalAge;
-  sh:name "maximum typical age"@en;
-  sh:description "Maximum typical age of the population within the dataset"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:nonNegativeInteger;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#minimum-typical-age> sh:path healthdcatap:minTypicalAge;
-  sh:name "minimum typical age"@en;
-  sh:description "Minimum typical age of the population within the dataset"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:nonNegativeInteger;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#modification-date> sh:path dct:modified;
-  sh:name "modification date"@en;
-  sh:description "The most recent date on which the Dataset was changed or modified."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#number-of-records> sh:path healthdcatap:numberOfRecords;
-  sh:name "number of records"@en;
-  sh:description "Size of the dataset in terms of the number of records"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:nonNegativeInteger;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#number-of-unique-infividuals> sh:path
-    healthdcatap:numberOfUniqueIndividuals;
-  sh:name "number of unique infividuals"@en;
-  sh:description "Number of records for unique individuals."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:nonNegativeInteger;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#other-identifier> sh:path adms:identifier;
-  sh:name "other identifier"@en;
-  sh:description "A secondary identifier of the Dataset, such as MAST/ADS17, DataCite18, DOI19, EZID20 or W3ID21"@en;
-  sh:node hri:IdentifierShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#personal-data> sh:path dpv:hasPersonalData;
-  sh:name "personal data"@en;
-  sh:description "Key elements that represent an individual in the dataset."@en;
-  sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv/dpv-pd#>;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#population-coverage> sh:path healthdcatap:populationCoverage;
-  sh:name "population coverage"@en;
-  sh:description "A definition of the population within the dataset"@en;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#publisher> sh:path dct:publisher;
-  sh:name "publisher"@en;
-  sh:description "An entity (organisation) responsible for making the Dataset available."@en;
-  sh:minCount 1;
-  sh:maxCount 1;
-  sh:node hri:AgentShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#purpose> sh:path dpv:hasPurpose;
-  sh:name "purpose"@en;
-  sh:description "A free text statement of the purpose of the processing of data or personal data."@en;
-  sh:nodeKind sh:IRI;
-  sh:defaultValue <https://w3id.org/dpv#>;
-  dash:viewer dash:LabelViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#qualified-attribution> sh:path prov:qualifiedAttribution;
-  sh:name "qualified attribution"@en;
-  sh:description "An Agent having some form of responsibility for the resource"@en;
-  sh:node hri:AttributionShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#qualified-relation> sh:path dcat:qualifiedRelation;
-  sh:name "qualified relation"@en;
-  sh:description "A description of a relationship with another resource"@en;
-  sh:node hri:RelationshipShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#quality-annotation> sh:path dqv:hasQualityAnnotation;
-  sh:name "quality annotation"@en;
-  sh:description "A statement related to quality of the Dataset, including rating, quality certificate, feedback that can be associated to the dataset"@en;
-  sh:node hri:QualityCertificateShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#release-date> sh:path dct:issued;
-  sh:name "release date"@en;
-  sh:description "The date of formal issuance (e.g., publication) of the Dataset."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:dateTime;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:DateTimePickerEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#retention-period> sh:path healthdcatap:retentionPeriod;
-  sh:name "retention period"@en;
-  sh:description "A temporal period which the dataset is available for secondary use"@en;
-  sh:maxCount 1;
-  sh:node hri:PeriodOfTimeShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#sample> sh:path adms:sample;
-  sh:name "sample"@en;
-  sh:description "A sample distribution of the dataset"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#source> sh:path dct:source;
-  sh:name "source"@en;
-  sh:description "A related dataset from which the described dataset is derived"@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#status> sh:path adms:status;
-  sh:name "status"@en;
-  sh:description "The status of a dataset"@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#temporal-coverage> sh:path dct:temporal;
-  sh:name "temporal coverage"@en;
-  sh:description "A temporal period that the Dataset covers."@en;
-  sh:node hri:PeriodOfTimeShape;
-  dash:viewer dash:DetailsViewer;
-  dash:editor dash:BlankNodeEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#temporal-resolution> sh:path dcat:temporalResolution;
-  sh:name "temporal resolution"@en;
-  sh:description "The minimum time period resolvable in the dataset."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:duration;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#theme> sh:path dcat:theme;
-  sh:name "theme"@en;
-  sh:description "A category of the Dataset"@en;
-  sh:minCount 1;
-  sh:nodeKind sh:IRI;
-  sh:defaultValue <http://publications.europa.eu/resource/authority/data-theme/HEAL>;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#title> sh:path dct:title;
-  sh:name "title"@en;
-  sh:description "A name given to the Dataset."@en;
-  sh:minCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#type> sh:path dct:type;
-  sh:name "type"@en;
-  sh:description "A type of the Dataset."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#version> sh:path dcat:version;
-  sh:name "version"@en;
-  sh:description "The version indicator (name or identifier) of a resource."@en;
-  sh:maxCount 1;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#version-notes> sh:path adms:versionNotes;
-  sh:name "version notes"@en;
-  sh:description "A description of the differences between this version and a previous version of the Dataset"@en;
-  sh:nodeKind sh:Literal;
-  sh:datatype xsd:string;
-  dash:viewer dash:LiteralViewer;
-  dash:editor dash:TextFieldEditor .
-
-<http://data.health-ri.nl/core/p2/DatasetShape#was-generated-by> sh:path prov:wasGeneratedBy;
-  sh:name "was generated by"@en;
-  sh:description "An activity that generated, or provides the business context for, the creation of the dataset."@en;
-  sh:nodeKind sh:IRI;
-  dash:viewer dash:URIViewer;
-  dash:editor dash:URIEditor .


### PR DESCRIPTION
Default values are causing problems in the FDP. The default values will cause the validation of the property even when the user did not enter any data in that field. 

Please note: You only have to check the PiecesShape folder, the other files are generated use this pieces, 
All pieces files are generated using the excel2RDF tool.

## Summary by Sourcery

Enhancements:
- Modify SHACL shape files to prevent default values from causing unnecessary validation