### PR TITLE
Add metadata and status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Core Metadata Schema Specification
 
+[![Project DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15395604.svg)](https://doi.org/10.5281/zenodo.15395604)
+[![Project Status - Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+![GitHub last commit](https://img.shields.io/github/last-commit/Health-RI/health-ri-metadata)
+![GitHub Created At](https://img.shields.io/github/created-at/Health-RI/health-ri-metadata)
+![GitHub Release](https://img.shields.io/github/v/release/Health-RI/health-ri-metadata)
+![GitHub Release Date](https://img.shields.io/github/release-date/Health-RI/health-ri-metadata)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/Health-RI/health-ri-metadata/latest)
+![GitHub contributors](https://img.shields.io/github/contributors/Health-RI/health-ri-metadata)
+
 This is version 2.0 of Health-RI core metadata schema.
 
 - [Previous published version](#previous-published-version)


### PR DESCRIPTION
This PR adds a set of informative badges to the README file to improve visibility:

- Project DOI badge (Zenodo)
- Project status (Active)
- GitHub repository info:
  - Last commit
  - Creation date
  - Latest release version and date
  - Commits since latest release
  - Number of contributors

## Summary by Sourcery

Documentation:
- Add badges for project DOI, project status, last commit, repository creation date, latest release version and date, commits since release, and contributors to the README.