### PR TITLE
feat: enforce ISO 8601 timestamp format

### DIFF
--- a/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Catalog.ttl
@@ -121,6 +121,8 @@ hri:CatalogShape a sh:NodeShape;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -140,6 +142,8 @@ hri:CatalogShape a sh:NodeShape;
   sh:name "release date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DataService.ttl
@@ -176,6 +176,8 @@ hri:DataServiceShape a sh:NodeShape;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Dataset.ttl
@@ -258,6 +258,8 @@ _:c43d47d21f8e45a0a6b80a39c0fca5708 rdf:first eu:NON_PUBLIC;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -345,6 +347,8 @@ _:c43d47d21f8e45a0a6b80a39c0fca5708 rdf:first eu:NON_PUBLIC;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/DatasetSeries.ttl
@@ -90,6 +90,8 @@ hri:DatasetSeriesShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -107,6 +109,8 @@ hri:DatasetSeriesShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/Distribution.ttl
@@ -158,6 +158,8 @@ hri:DistributionShape a sh:NodeShape;
   sh:name "modification date"@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -174,6 +176,8 @@ hri:DistributionShape a sh:NodeShape;
   sh:description "The date the dataset distribution was issued."@en;
   sh:maxCount 1;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 

--- a/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
+++ b/Formalisation(shacl)/Core/PiecesShape/PeriodOfTime.ttl
@@ -45,6 +45,8 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .
 
@@ -54,5 +56,7 @@ hri:PeriodOfTimeShape a sh:NodeShape;
   sh:maxCount 1;
   sh:nodeKind sh:Literal;
   sh:datatype xsd:dateTime;
+  sh:pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,3})?(Z|[+-]\\d{2}:\\d{2})$" ;
+  sh:message "Value must be a valid ISO 8601 timestamp. For example: 2024-07-11T11:48:00.923Z" ;
   dash:viewer dash:LiteralViewer;
   dash:editor dash:DateTimePickerEditor .


### PR DESCRIPTION
This change ensures that all timestamps follow the ISO 8601 standard. Adds validation and updates related logic accordingly.

Closes again #91