### PR TITLE
docs: adjust changelog for patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## v2.0.3
 
 Enhancements:
-- Added Excel with instructions for using the different controlled vocabularies in the model
+- Added Excel file with instructions for using the different controlled vocabularies in the model
 - Exchanged the Readme file in this repo by the more user-friendly documentation: https://health-ri.github.io/metadata-documentation/
 - Adjusted several usage notes:
   - Catalogue - licence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+## v2.0.3
+
+Enhancements:
+- Added Excel with instructions for using the different controlled vocabularies in the model
+- Exchanged the Readme file in this repo by the more user-friendly documentation: https://health-ri.github.io/metadata-documentation/
+- Adjusted several usage notes:
+  - Catalogue - licence
+  - Distribution - media type
+  - Dataset - applicableLegislation
+  - Dataset - legalBasis
+  - Dataset - purpose
+
+Chores:
+- Updated the CONTRIBUTING.md 
+
+
 ## v2.0.2
 
 Bug fixes:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/Health-RI/health-ri-metadata/latest)
 ![GitHub contributors](https://img.shields.io/github/contributors/Health-RI/health-ri-metadata)
 
-# Core metadata schema 
-This repo holds the **Health-RI Core metadata schema**, which is used to in the [National Health Data Catalogue]([https://catalogus.healthdata.nl/).
+# Health-RI core metadata schema 
+This repo holds the **Health-RI Core metadata schema**, which is used in the [National Health Data Catalogue]([https://catalogus.healthdata.nl/).
 
 ## Technical specifications
 To view specifics of the metadata model per class and property, please visit the **[documentation page](https://health-ri.github.io/metadata-documentation/)**.


### PR DESCRIPTION
## Summary by Sourcery

Document the v2.0.3 patch release and align README wording with the updated documentation.

Documentation:
- Add v2.0.3 entry to the changelog with enhancements and chore updates.
- Clarify README title casing and fix wording for the Health-RI core metadata schema description.